### PR TITLE
Feature/#10 암호화 Key API 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'//JDBC
     runtimeOnly 'com.mysql:mysql-connector-j'//MySQL
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'//Redis
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/org/mju_likelion/festival/auth/controller/AuthController.java
+++ b/src/main/java/org/mju_likelion/festival/auth/controller/AuthController.java
@@ -1,0 +1,20 @@
+package org.mju_likelion.festival.auth.controller;
+
+import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.auth.dto.response.KeyResponse;
+import org.mju_likelion.festival.auth.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+public class AuthController {
+
+  private final AuthService authService;
+
+  @GetMapping("/auth/key")
+  public ResponseEntity<KeyResponse> getKey() {
+    return ResponseEntity.ok(authService.getKey());
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/auth/domain/RsaKey.java
+++ b/src/main/java/org/mju_likelion/festival/auth/domain/RsaKey.java
@@ -1,0 +1,11 @@
+package org.mju_likelion.festival.auth.domain;
+
+/**
+ * RSA Key 정보 클래스
+ *
+ * @param publicKey  RSA Public Key
+ * @param privateKey RSA Private Key
+ */
+public record RsaKey(String publicKey, String privateKey) {
+
+}

--- a/src/main/java/org/mju_likelion/festival/auth/domain/RsaKeyStrategy.java
+++ b/src/main/java/org/mju_likelion/festival/auth/domain/RsaKeyStrategy.java
@@ -1,0 +1,11 @@
+package org.mju_likelion.festival.auth.domain;
+
+/**
+ * RSA Key 전략 Enum
+ * <p>
+ * RSA Key 를 관리하는 전략을 정의한다.
+ */
+public enum RsaKeyStrategy {
+  REDIS, // Private Key 를 Redis 에 저장
+  TOKEN // Private Key 와 만료 시간을 Token 에 저장
+}

--- a/src/main/java/org/mju_likelion/festival/auth/dto/response/KeyResponse.java
+++ b/src/main/java/org/mju_likelion/festival/auth/dto/response/KeyResponse.java
@@ -1,0 +1,14 @@
+package org.mju_likelion.festival.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.mju_likelion.festival.auth.domain.RsaKeyStrategy;
+
+@Getter
+@AllArgsConstructor
+public class KeyResponse {
+
+  private final String rsaPublicKey;
+  private final String credentialKey;
+  private final RsaKeyStrategy rsaKeyStrategy;
+}

--- a/src/main/java/org/mju_likelion/festival/auth/service/AuthService.java
+++ b/src/main/java/org/mju_likelion/festival/auth/service/AuthService.java
@@ -1,0 +1,36 @@
+package org.mju_likelion.festival.auth.service;
+
+import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.auth.domain.RsaKey;
+import org.mju_likelion.festival.auth.domain.RsaKeyStrategy;
+import org.mju_likelion.festival.auth.dto.response.KeyResponse;
+import org.mju_likelion.festival.auth.util.key.manager.RsaKeyManager;
+import org.mju_likelion.festival.auth.util.key.manager.RsaKeyManagerContext;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class AuthService {
+
+  private final RsaKeyManagerContext rsaKeyManagerContext;
+
+  public KeyResponse getKey() {
+    RsaKeyManager rsaKeyManager = rsaKeyManager();
+
+    RsaKey rsaKey = rsaKeyManager.generateRsaKey();
+
+    String credentialKey = rsaKeyManager.savePrivateKey(rsaKey.privateKey());
+
+    RsaKeyStrategy rsaKeyStrategy = rsaKeyManager.rsaKeyStrategy();
+
+    return new KeyResponse(rsaKey.publicKey(), credentialKey, rsaKeyStrategy);
+  }
+
+  private RsaKeyManager rsaKeyManager() {
+    return rsaKeyManagerContext.rsaKeyManager();
+  }
+
+  private RsaKeyManager rsaKeyManager(RsaKeyStrategy rsaKeyStrategy) {
+    return rsaKeyManagerContext.rsaKeyManager(rsaKeyStrategy);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/auth/util/encryption/EncryptionUtil.java
+++ b/src/main/java/org/mju_likelion/festival/auth/util/encryption/EncryptionUtil.java
@@ -1,0 +1,69 @@
+package org.mju_likelion.festival.auth.util.encryption;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.mju_likelion.festival.common.exception.InternalServerException;
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * 암호화 유틸리티 클래스 대칭 키 알고리즘을 사용하여 주어진 문자열을 암호화하거나 복호화한다.
+ */
+@Service
+public class EncryptionUtil {
+
+  private static final String ALGORITHM = "AES";
+  private static final String TRANSFORMATION = "AES/CBC/PKCS5Padding";
+  private final SecretKey secretKey;
+  private final IvParameterSpec ivParameterSpec;
+
+  public EncryptionUtil(
+      @Value("${security.encryption.secret-key}") final String base64EncodedKey,
+      @Value("${security.encryption.iv}") final String base64EncodedIv) {
+
+    byte[] decodedKey = Base64.getDecoder().decode(base64EncodedKey);
+    this.secretKey = new SecretKeySpec(decodedKey, ALGORITHM);
+    byte[] decodedIv = Base64.getDecoder().decode(base64EncodedIv);
+    this.ivParameterSpec = new IvParameterSpec(decodedIv);
+  }
+
+  /**
+   * 주어진 문자열을 대칭키로 암호화한다.
+   *
+   * @param plainText 암호화할 문자열
+   * @return 암호화된 문자열
+   */
+  public String encrypt(String plainText) {
+    try {
+      Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+      cipher.init(Cipher.ENCRYPT_MODE, secretKey, ivParameterSpec);
+      byte[] encryptedBytes = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+      return Base64.getEncoder().encodeToString(encryptedBytes);
+    } catch (Exception e) {
+      throw new InternalServerException(ErrorType.ENCRYPT_ERROR, e.getMessage());
+    }
+  }
+
+  /**
+   * 주어진 암호화된 문자열을 대칭키로 복호화한다.
+   *
+   * @param encryptedText 복호화할 문자열
+   * @return 복호화된 문자열
+   */
+  public String decrypt(String encryptedText) {
+    try {
+      Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+      cipher.init(Cipher.DECRYPT_MODE, secretKey, ivParameterSpec);
+      byte[] decodedBytes = Base64.getDecoder().decode(encryptedText);
+      byte[] decryptedBytes = cipher.doFinal(decodedBytes);
+      return new String(decryptedBytes, StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      throw new InternalServerException(ErrorType.DECRYPT_ERROR, e.getMessage());
+    }
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/auth/util/key/RsaKeyUtil.java
+++ b/src/main/java/org/mju_likelion/festival/auth/util/key/RsaKeyUtil.java
@@ -1,0 +1,129 @@
+package org.mju_likelion.festival.auth.util.key;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.RSA_KEY_ERROR;
+
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import org.mju_likelion.festival.auth.domain.RsaKey;
+import org.mju_likelion.festival.common.exception.InternalServerException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RsaKeyUtil {
+
+  private final String instanceType = "RSA";
+  private final int keySize;
+
+  public RsaKeyUtil(@Value("${key.size}") int keySize) {
+    this.keySize = keySize;
+  }
+
+  public RsaKey generateRsaKey() {
+    KeyPair keyPair = generateKeypair();
+
+    String publicKey = base64EncodeToString(keyPair.getPublic().getEncoded());
+    String privateKey = base64EncodeToString(keyPair.getPrivate().getEncoded());
+
+    return new RsaKey(publicKey, privateKey);
+  }
+
+  private KeyPair generateKeypair() {
+    try {
+      KeyPairGenerator keyPairGen = KeyPairGenerator.getInstance(instanceType);
+      keyPairGen.initialize(keySize, new SecureRandom());
+
+      return keyPairGen.genKeyPair();
+    } catch (Exception e) {
+      throw new InternalServerException(RSA_KEY_ERROR, e.getMessage());
+    }
+  }
+
+  /**
+   * RSA 암호화, Public Key 로 plainText 를 암호화한다.
+   *
+   * @param plainText 암호화할 문자열
+   * @param publicKey RSA Public Key
+   * @return 암호화된 문자열
+   * @deprecated Test 에서만 사용한다.
+   */
+  public String rsaEncode(String plainText, String publicKey) {
+    try {
+      Cipher cipher = Cipher.getInstance(instanceType);
+      cipher.init(Cipher.ENCRYPT_MODE, convertPublicKey(publicKey));
+
+      byte[] plainTextByte = cipher.doFinal(plainText.getBytes());
+
+      return base64EncodeToString(plainTextByte);
+    } catch (Exception e) {
+      throw new RuntimeException(e.getMessage());
+    }
+  }
+
+  /**
+   * RSA 복호화, Private Key 로 암호화된 문자열을 복호화한다.
+   *
+   * @param encryptedPlainText 암호화된 문자열
+   * @param privateKey         RSA Private Key
+   * @return 복호화된 문자열
+   */
+  public String rsaDecode(String encryptedPlainText, String privateKey) {
+    try {
+      byte[] encryptedPlainTextByte = Base64.getDecoder().decode(encryptedPlainText.getBytes());
+
+      Cipher cipher = Cipher.getInstance(instanceType);
+      cipher.init(Cipher.DECRYPT_MODE, convertPrivateKey(privateKey));
+
+      return new String(cipher.doFinal(encryptedPlainTextByte));
+    } catch (Exception e) {
+      throw new InternalServerException(RSA_KEY_ERROR, e.getMessage());
+    }
+  }
+
+  /**
+   * String 형태의 PublicKey 를 PublicKey 객체로 변환한다.
+   *
+   * @param publicKey String 형태의 PublicKey
+   * @return PublicKey 객체
+   * @deprecated Test 에서만 사용한다.
+   */
+  public PublicKey convertPublicKey(String publicKey) {
+    try {
+      KeyFactory keyFactory = KeyFactory.getInstance(instanceType);
+      byte[] publicKeyByte = Base64.getDecoder().decode(publicKey.getBytes());
+
+      return keyFactory.generatePublic(new X509EncodedKeySpec(publicKeyByte));
+    } catch (Exception e) {
+      throw new RuntimeException(e.getMessage());
+    }
+  }
+
+  /**
+   * String 형태의 PrivateKey 를 PrivateKey 객체로 변환한다.
+   *
+   * @param privateKey String 형태의 PrivateKey
+   * @return PrivateKey 객체
+   */
+  public PrivateKey convertPrivateKey(String privateKey) {
+    try {
+      KeyFactory keyFactory = KeyFactory.getInstance(instanceType);
+      byte[] privateKeyByte = Base64.getDecoder().decode(privateKey.getBytes());
+
+      return keyFactory.generatePrivate(new PKCS8EncodedKeySpec(privateKeyByte));
+    } catch (Exception e) {
+      throw new InternalServerException(RSA_KEY_ERROR, e.getMessage());
+    }
+  }
+
+  private String base64EncodeToString(byte[] byteData) {
+    return Base64.getEncoder().encodeToString(byteData);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/auth/util/key/manager/RedisRsaKeyManager.java
+++ b/src/main/java/org/mju_likelion/festival/auth/util/key/manager/RedisRsaKeyManager.java
@@ -1,0 +1,49 @@
+package org.mju_likelion.festival.auth.util.key.manager;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.auth.domain.RsaKey;
+import org.mju_likelion.festival.auth.domain.RsaKeyStrategy;
+import org.mju_likelion.festival.auth.util.key.RsaKeyUtil;
+import org.mju_likelion.festival.common.util.redis.RedisUtil;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class RedisRsaKeyManager implements RsaKeyManager {
+
+  private final RedisUtil<String, String> redisUtil;
+  private final RsaKeyUtil rsaKeyUtil;
+  private final String keyPrefix = "PRIVATE_KEY:";
+
+  @Override
+  public RsaKey generateRsaKey() {
+    return rsaKeyUtil.generateRsaKey();
+  }
+
+  @Override
+  public String savePrivateKey(String privateKey) {
+    String redisKey = UUID.randomUUID().toString();
+    redisUtil.insert(formatRedisKey(redisKey), privateKey, this.rsaKeyExpireSecond);
+    return redisKey;
+  }
+
+  @Override
+  public String decryptByKey(String encryptedText, String key) {
+    String privateKey = getPrivateKey(key);
+    return rsaKeyUtil.rsaDecode(encryptedText, privateKey);
+  }
+
+  @Override
+  public RsaKeyStrategy rsaKeyStrategy() {
+    return RsaKeyStrategy.REDIS;
+  }
+
+  private String getPrivateKey(String key) {
+    return redisUtil.select(key).orElseThrow();
+  }
+
+  private String formatRedisKey(String key) {
+    return keyPrefix + key;
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/auth/util/key/manager/RsaKeyManager.java
+++ b/src/main/java/org/mju_likelion/festival/auth/util/key/manager/RsaKeyManager.java
@@ -1,0 +1,42 @@
+package org.mju_likelion.festival.auth.util.key.manager;
+
+import org.mju_likelion.festival.auth.domain.RsaKey;
+import org.mju_likelion.festival.auth.domain.RsaKeyStrategy;
+
+public interface RsaKeyManager {
+
+  // Rsa Key 의 유효 시간 (초)
+  long rsaKeyExpireSecond = 30;
+
+  /**
+   * RSA Key 를 생성한다.
+   *
+   * @return RSA Key
+   */
+  RsaKey generateRsaKey();
+
+
+  /**
+   * RSA Private Key 를 저장한 후, 해당 Private Key 를 식별할 수 있는 Key 를 반환한다.
+   *
+   * @param privateKey RSA Private Key
+   * @return RSA Private Key 를 얻을 수 있는 Key
+   */
+  String savePrivateKey(String privateKey);
+
+  /**
+   * RSA Private Key 를 이용하여 암호화된 텍스트를 복호화한다.
+   *
+   * @param plainText 암호화된 텍스트
+   * @param key       RSA Private Key 를 식별할 수 있는 Key
+   * @return 복호화된 텍스트
+   */
+  String decryptByKey(String plainText, String key);
+
+  /**
+   * RsaKeyStrategy 를 반환한다.
+   *
+   * @return RsaKeyStrategy
+   */
+  RsaKeyStrategy rsaKeyStrategy();
+}

--- a/src/main/java/org/mju_likelion/festival/auth/util/key/manager/RsaKeyManagerContext.java
+++ b/src/main/java/org/mju_likelion/festival/auth/util/key/manager/RsaKeyManagerContext.java
@@ -1,0 +1,49 @@
+package org.mju_likelion.festival.auth.util.key.manager;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.mju_likelion.festival.auth.domain.RsaKeyStrategy;
+import org.mju_likelion.festival.common.util.redis.RedisAvailabilityChecker;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * RsaKeyManager 컨텍스트
+ * <p>
+ * Redis 가 사용 가능한 경우 RedisRsaKeyManager 를 사용하고, 그렇지 않은 경우 TokenRsaKeyManager 를 사용한다.
+ */
+@Service
+public class RsaKeyManagerContext {
+
+  private final RedisAvailabilityChecker redisAvailabilityChecker;
+  private final Map<RsaKeyStrategy, RsaKeyManager> rsaKeyManagers;
+
+  @Autowired
+  public RsaKeyManagerContext(RedisAvailabilityChecker redisAvailabilityChecker,
+      List<RsaKeyManager> rsaKeyManagerList) {
+    this.redisAvailabilityChecker = redisAvailabilityChecker;
+    this.rsaKeyManagers = rsaKeyManagerList.stream()
+        .collect(Collectors.toMap(RsaKeyManager::rsaKeyStrategy, Function.identity()));
+  }
+
+  private RsaKeyManager redisRsaKeyManager() {
+    return rsaKeyManagers.get(RsaKeyStrategy.REDIS);
+  }
+
+  private RsaKeyManager tokenRsaKeyManager() {
+    return rsaKeyManagers.get(RsaKeyStrategy.TOKEN);
+  }
+
+  public RsaKeyManager rsaKeyManager() {
+    if (redisAvailabilityChecker.isAvailable()) {
+      return redisRsaKeyManager();
+    }
+    return tokenRsaKeyManager();
+  }
+
+  public RsaKeyManager rsaKeyManager(RsaKeyStrategy rsaKeyStrategy) {
+    return rsaKeyManagers.get(rsaKeyStrategy);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/auth/util/key/manager/TokenRsaKeyManager.java
+++ b/src/main/java/org/mju_likelion/festival/auth/util/key/manager/TokenRsaKeyManager.java
@@ -1,0 +1,37 @@
+package org.mju_likelion.festival.auth.util.key.manager;
+
+import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.auth.domain.RsaKey;
+import org.mju_likelion.festival.auth.domain.RsaKeyStrategy;
+import org.mju_likelion.festival.auth.util.key.RsaKeyUtil;
+import org.mju_likelion.festival.auth.util.token.CredentialTokenUtil;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class TokenRsaKeyManager implements RsaKeyManager {
+
+  private final RsaKeyUtil rsaKeyUtil;
+  private final CredentialTokenUtil credentialTokenUtil;
+
+  @Override
+  public RsaKey generateRsaKey() {
+    return rsaKeyUtil.generateRsaKey();
+  }
+
+  @Override
+  public String savePrivateKey(String privateKey) {
+    return credentialTokenUtil.getEncryptedCredentialToken(privateKey, this.rsaKeyExpireSecond);
+  }
+
+  @Override
+  public String decryptByKey(String plainText, String key) {
+    String privateKey = credentialTokenUtil.parsePrivateKey(key);
+    return rsaKeyUtil.rsaDecode(plainText, privateKey);
+  }
+
+  @Override
+  public RsaKeyStrategy rsaKeyStrategy() {
+    return RsaKeyStrategy.TOKEN;
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/auth/util/token/CredentialToken.java
+++ b/src/main/java/org/mju_likelion/festival/auth/util/token/CredentialToken.java
@@ -1,0 +1,41 @@
+package org.mju_likelion.festival.auth.util.token;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 인증 토큰을 나타내는 클래스.
+ * <p>
+ * private key와 만료 시간을 가지고 있다.
+ * </p>
+ * Redis 장애 시 인증 토큰을 저장하기 위해 사용된다.
+ */
+@Getter
+@AllArgsConstructor
+public class CredentialToken {
+
+  private final String privateKey;
+  private final LocalDateTime expirationTime;
+
+  /**
+   * 토큰 문자열을 CredentialToken 객체로 변환한다.
+   *
+   * @param tokenString 토큰 문자열
+   * @return CredentialToken 객체
+   */
+  public static CredentialToken fromTokenString(String tokenString) {
+    String privateKey = tokenString.split(",")[0];
+    LocalDateTime expirationTime = LocalDateTime.parse(tokenString.split(",")[1]);
+    return new CredentialToken(privateKey, expirationTime);
+  }
+
+  /**
+   * CredentialToken 객체를 토큰 문자열로 변환한다.
+   *
+   * @return 토큰 문자열
+   */
+  public String toTokenString() {
+    return privateKey + "," + expirationTime;
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/auth/util/token/CredentialTokenUtil.java
+++ b/src/main/java/org/mju_likelion/festival/auth/util/token/CredentialTokenUtil.java
@@ -1,0 +1,64 @@
+package org.mju_likelion.festival.auth.util.token;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.CREDENTIAL_TOKEN_EXPIRED;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.auth.util.encryption.EncryptionUtil;
+import org.mju_likelion.festival.common.exception.BadRequestException;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class CredentialTokenUtil {
+
+  private final EncryptionUtil encryptionUtil;
+
+  /**
+   * CredentialToken 을 암호화하여 반환
+   *
+   * @param privateKey             privateKey 문자열
+   * @param tokenExpirationSeconds 토큰 만료 시간
+   * @return 암호화된 CredentialToken
+   */
+  public String getEncryptedCredentialToken(String privateKey, long tokenExpirationSeconds) {
+    CredentialToken credentialToken = generateToken(privateKey, tokenExpirationSeconds);
+    return encryptionUtil.encrypt(credentialToken.toTokenString());
+  }
+
+  /**
+   * CredentialToken 생성
+   *
+   * @param privateKey             privateKey 문자열
+   * @param tokenExpirationSeconds 토큰 만료 시간
+   * @return CredentialToken
+   */
+  private CredentialToken generateToken(String privateKey, long tokenExpirationSeconds) {
+    return new CredentialToken(privateKey, LocalDateTime.now().plusSeconds(tokenExpirationSeconds));
+  }
+
+  /**
+   * 암호화된 토큰을 복호화하여 privateKey 반환
+   *
+   * @param encryptedToken 암호화된 토큰
+   * @return privateKey
+   */
+  public String parsePrivateKey(String encryptedToken) {
+    String decryptedToken = encryptionUtil.decrypt(encryptedToken);
+    CredentialToken credentialToken = CredentialToken.fromTokenString(decryptedToken);
+    validateCredentialToken(credentialToken);
+
+    return credentialToken.getPrivateKey();
+  }
+
+  /**
+   * CredentialToken 만료 여부 확인
+   *
+   * @param credentialToken CredentialToken
+   */
+  private void validateCredentialToken(CredentialToken credentialToken) {
+    if (credentialToken.getExpirationTime().isBefore(LocalDateTime.now())) {
+      throw new BadRequestException(CREDENTIAL_TOKEN_EXPIRED);
+    }
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/config/RedisConfig.java
+++ b/src/main/java/org/mju_likelion/festival/common/config/RedisConfig.java
@@ -1,0 +1,65 @@
+package org.mju_likelion.festival.common.config;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.resource.DefaultClientResources;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisConnectionUtils;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String redisHost;
+  @Value("${spring.data.redis.port}")
+  private int redisPort;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    RedisStandaloneConfiguration serverConfig = new RedisStandaloneConfiguration(redisHost,
+        redisPort);
+
+    LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+        .clientResources(DefaultClientResources.create())
+        .clientOptions(ClientOptions.builder()
+            .autoReconnect(true) // 자동 재연결
+            .disconnectedBehavior(
+                ClientOptions.DisconnectedBehavior.REJECT_COMMANDS) // 연결이 끊겼을 때 명령 거부
+            .build())
+        .build();
+
+    return new LettuceConnectionFactory(serverConfig, clientConfig);
+  }
+
+  @Bean
+  public <K, V> RedisTemplate<K, V> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+    RedisTemplate<K, V> template = new RedisTemplate<>();
+    template.setConnectionFactory(redisConnectionFactory);
+    template.setKeySerializer(new GenericJackson2JsonRedisSerializer());
+    template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+    return template;
+  }
+
+  /**
+   * Redis 서버와 연결 가능한지 확인한다.
+   *
+   * @return 연결 가능 여부
+   */
+  public boolean isConnectionAvailable() {
+    try (RedisConnection connection = RedisConnectionUtils.getConnection(
+        redisConnectionFactory())) {
+      return Objects.equals(connection.ping(), "PONG");
+    } catch (Exception e) {
+      return false;
+    }
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/exception/BadRequestException.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/BadRequestException.java
@@ -1,0 +1,15 @@
+package org.mju_likelion.festival.common.exception;
+
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.http.HttpStatus;
+
+public class BadRequestException extends CustomException {
+
+  public BadRequestException(ErrorType errorType) {
+    super(errorType, HttpStatus.BAD_REQUEST);
+  }
+
+  public BadRequestException(ErrorType errorType, String detail) {
+    super(errorType, detail, HttpStatus.BAD_REQUEST);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/exception/ConflictException.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/ConflictException.java
@@ -1,0 +1,15 @@
+package org.mju_likelion.festival.common.exception;
+
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.http.HttpStatus;
+
+public class ConflictException extends CustomException {
+
+  public ConflictException(ErrorType errorType) {
+    super(errorType, HttpStatus.CONFLICT);
+  }
+
+  public ConflictException(ErrorType errorType, String detail) {
+    super(errorType, detail, HttpStatus.CONFLICT);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/exception/CustomException.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/CustomException.java
@@ -1,0 +1,27 @@
+package org.mju_likelion.festival.common.exception;
+
+import lombok.Getter;
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public abstract class CustomException extends RuntimeException {
+
+  private final ErrorType errorType;
+  private final String detail;
+  private final HttpStatus httpStatus;
+
+  protected CustomException(final ErrorType errorType, HttpStatus httpStatus) {
+    super(errorType.getMessage());
+    this.errorType = errorType;
+    this.detail = null;
+    this.httpStatus = httpStatus;
+  }
+
+  protected CustomException(final ErrorType errorType, final String detail, HttpStatus httpStatus) {
+    super(errorType.getMessage());
+    this.errorType = errorType;
+    this.detail = detail;
+    this.httpStatus = httpStatus;
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/exception/ForbiddenException.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/ForbiddenException.java
@@ -1,0 +1,15 @@
+package org.mju_likelion.festival.common.exception;
+
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenException extends CustomException {
+
+  public ForbiddenException(ErrorType errorType) {
+    super(errorType, HttpStatus.FORBIDDEN);
+  }
+
+  public ForbiddenException(ErrorType errorType, String detail) {
+    super(errorType, detail, HttpStatus.FORBIDDEN);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/exception/InternalServerException.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/InternalServerException.java
@@ -1,0 +1,15 @@
+package org.mju_likelion.festival.common.exception;
+
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.http.HttpStatus;
+
+public class InternalServerException extends CustomException {
+
+  public InternalServerException(final ErrorType errorType) {
+    super(errorType, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  public InternalServerException(final ErrorType errorType, final String detail) {
+    super(errorType, detail, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/exception/NotFoundException.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/NotFoundException.java
@@ -1,0 +1,15 @@
+package org.mju_likelion.festival.common.exception;
+
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends CustomException {
+
+  public NotFoundException(ErrorType errorType) {
+    super(errorType, HttpStatus.NOT_FOUND);
+  }
+
+  public NotFoundException(ErrorType errorType, String detail) {
+    super(errorType, detail, HttpStatus.NOT_FOUND);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/exception/UnauthorizedException.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/UnauthorizedException.java
@@ -1,0 +1,15 @@
+package org.mju_likelion.festival.common.exception;
+
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends CustomException {
+
+  public UnauthorizedException(ErrorType errorType) {
+    super(errorType, HttpStatus.UNAUTHORIZED);
+  }
+
+  public UnauthorizedException(ErrorType errorType, String detail) {
+    super(errorType, detail, HttpStatus.UNAUTHORIZED);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/exception/controller/ExceptionController.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/controller/ExceptionController.java
@@ -1,0 +1,57 @@
+package org.mju_likelion.festival.common.exception.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.mju_likelion.festival.common.exception.BadRequestException;
+import org.mju_likelion.festival.common.exception.CustomException;
+import org.mju_likelion.festival.common.exception.dto.ErrorResponse;
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionController {
+
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<ErrorResponse> customExceptionHandler(final CustomException e) {
+    writeLog(e);
+    return ResponseEntity.status(e.getHttpStatus()).body(ErrorResponse.res(e));
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> springValidationExceptionHandler(
+      final MethodArgumentNotValidException e) {
+    String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+
+    BadRequestException badRequestException = new BadRequestException(
+        ErrorType.INVALID_REQUEST_BODY, message);
+
+    writeLog(badRequestException);
+    return ResponseEntity.badRequest().body(ErrorResponse.res(badRequestException));
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> exceptionHandler(final Exception e) {
+    writeLog(e);
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ErrorResponse.res(e));
+  }
+
+  private void writeLog(CustomException customException) {
+    ErrorType errorType = customException.getErrorType();
+
+    String exceptionName = customException.getClass().getSimpleName();
+    String message = errorType.getMessage();
+    String detail = customException.getDetail();
+
+    log.error("[{}]{}:{}", exceptionName, message, detail);
+  }
+
+  private void writeLog(Exception exception) {
+    String exceptionName = exception.getClass().getSimpleName();
+    String message = exception.getMessage();
+    log.error("[{}]:{}", exceptionName, message);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/exception/dto/ErrorResponse.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/dto/ErrorResponse.java
@@ -1,0 +1,35 @@
+package org.mju_likelion.festival.common.exception.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.mju_likelion.festival.common.exception.CustomException;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+
+  private final int errorCode;
+  private final String message;
+  private final String detail;
+
+  public static ErrorResponse res(final CustomException customException) {
+    int errorCode = customException.getErrorType().getCode();
+    String message = customException.getErrorType().getMessage();
+    String detail = customException.getDetail();
+    return new ErrorResponse(errorCode, message, detail);
+  }
+
+  public static ErrorResponse res(final Exception e) {
+    return new ErrorResponse(9999, e.getMessage(), null);
+  }
+
+  @Override
+  public String toString() {
+    return "ErrorResponse{" +
+        "errorCode=" + errorCode +
+        ", message='" + message +
+        ", detail='" + detail +
+        '}';
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
@@ -1,0 +1,22 @@
+package org.mju_likelion.festival.common.exception.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorType {
+
+  ENCRYPT_ERROR(1000, "암호화에 실패했습니다."),
+  DECRYPT_ERROR(1001, "복호화에 실패했습니다."),
+  RSA_KEY_ERROR(1002, "RSA 키 처리 중 오류가 발생했습니다."),
+  CREDENTIAL_TOKEN_EXPIRED(1003, "자격 증명 토큰이 만료되었습니다."),
+
+  INVALID_REQUEST_BODY(4000, "요청 바디가 잘못되었습니다."),
+
+  REDIS_ERROR(6000, "Redis 에러가 발생했습니다.");
+
+
+  private final int code;
+  private final String message;
+}

--- a/src/main/java/org/mju_likelion/festival/common/util/redis/RedisAvailabilityChecker.java
+++ b/src/main/java/org/mju_likelion/festival/common/util/redis/RedisAvailabilityChecker.java
@@ -1,0 +1,27 @@
+package org.mju_likelion.festival.common.util.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.mju_likelion.festival.common.config.RedisConfig;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisAvailabilityChecker {
+
+  private static final long REDIS_CHECK_INTERVAL = 10000; // 10초
+  private final RedisConfig redisConfig;
+  private volatile boolean redisAvailable = false; // 멀티스레드 환경 가시성 보장
+
+  public boolean isAvailable() {
+    return redisAvailable;
+  }
+
+  /**
+   * Redis 연결 상태를 주기적으로 확인하여 업데이트한다.
+   */
+  @Scheduled(fixedDelay = REDIS_CHECK_INTERVAL)
+  public void updateAvailability() {
+    redisAvailable = redisConfig.isConnectionAvailable();
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/util/redis/RedisUtil.java
+++ b/src/main/java/org/mju_likelion/festival/common/util/redis/RedisUtil.java
@@ -1,0 +1,35 @@
+package org.mju_likelion.festival.common.util.redis;
+
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.REDIS_ERROR;
+
+import java.time.Duration;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.common.exception.InternalServerException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class RedisUtil<K, V> {
+
+  private final RedisTemplate<K, V> redisTemplate;
+
+  public void insert(K key, V value, long offset) {
+    try {
+      this.redisTemplate.opsForValue().set(key, value, Duration.ofSeconds(offset));
+    } catch (Exception e) {
+      throw new InternalServerException(REDIS_ERROR, e.getMessage());
+    }
+  }
+
+  public Optional<V> select(K key) {
+    try {
+      V value = this.redisTemplate.opsForValue().get(key);
+      return Optional.ofNullable(value);
+    } catch (Exception e) {
+      throw new InternalServerException(REDIS_ERROR, e.getMessage());
+    }
+  }
+}

--- a/src/test/java/org/mju_likelion/festival/auth/util/encryption/EncryptionUtilTest.java
+++ b/src/test/java/org/mju_likelion/festival/auth/util/encryption/EncryptionUtilTest.java
@@ -1,0 +1,39 @@
+package org.mju_likelion.festival.auth.util.encryption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mju_likelion.festival.common.annotation.ApplicationTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("EncryptionUtil")
+@ApplicationTest
+public class EncryptionUtilTest {
+
+  @Autowired
+  private EncryptionUtil encryptionUtil;
+
+  private static Stream<String> plainTexts() {
+    return Stream.of(
+        "asdfsagsaewr",
+        "asfdccc",
+        "12132353246234234"
+    );
+  }
+
+  @DisplayName("암호화된 문자열을 복호화하면 원래 문자열이 나온다.")
+  @ParameterizedTest(name = "plainText: {0}")
+  @MethodSource("plainTexts")
+  void testEncryptDecrypt(String plainText) {
+    // when
+    String encryptedText = encryptionUtil.encrypt(plainText);
+    String decryptedText = encryptionUtil.decrypt(encryptedText);
+
+    // then
+    assertThat(decryptedText).isEqualTo(plainText);
+  }
+
+}

--- a/src/test/java/org/mju_likelion/festival/auth/util/key/RsaKeyUtilTest.java
+++ b/src/test/java/org/mju_likelion/festival/auth/util/key/RsaKeyUtilTest.java
@@ -1,0 +1,146 @@
+package org.mju_likelion.festival.auth.util.key;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mju_likelion.festival.auth.domain.RsaKey;
+import org.mju_likelion.festival.common.annotation.ApplicationTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("RsaKeyUtil")
+@ApplicationTest
+public class RsaKeyUtilTest {
+
+  @Autowired
+  private RsaKeyUtil rsaKeyUtil;
+
+  private static Stream<String> plainTexts() {
+    return Stream.of(
+        " ",
+        "",
+        "asdfsagsaewr",
+        "asfdccc",
+        "12132353246234234"
+    );
+  }
+
+  private static Stream<String> invalidPrivateKeys() {
+    return Stream.of(
+        " ",
+        "",
+        "asdfsagsaewr",
+        "asfdccc",
+        "12132353246234234"
+    );
+  }
+
+  @DisplayName("Public Key 로 암호화된 문자열을 쌍이 맞는 Private Key 로 복호화하면 원래 문자열이 나온다.")
+  @ParameterizedTest(name = "plainText: {0}")
+  @MethodSource("plainTexts")
+  void testRsaEncodeDecode(String plainText) {
+    RsaKey rsaKey = rsaKeyUtil.generateRsaKey();
+    String publicKey = rsaKey.publicKey();
+    String privateKey = rsaKey.privateKey();
+
+    // when
+    String encryptedText = rsaKeyUtil.rsaEncode(plainText, publicKey);
+    String decryptedText = rsaKeyUtil.rsaDecode(encryptedText, privateKey);
+
+    // then
+    assertThat(decryptedText).isEqualTo(plainText);
+  }
+
+  @DisplayName("Public Key 로 복호화하면 예외가 발생한다.")
+  @ParameterizedTest(name = "plainText: {0}")
+  @MethodSource("plainTexts")
+  void testRsaDecodeWithPublicKey(String plainText) {
+    //given
+    RsaKey rsaKey = rsaKeyUtil.generateRsaKey();
+    String publicKey = rsaKey.publicKey();
+    String encryptedText = rsaKeyUtil.rsaEncode(plainText, publicKey);
+
+    // when, then
+    assertThatThrownBy(() -> rsaKeyUtil.rsaDecode(encryptedText, publicKey))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @DisplayName("Public Key 로 암호화하면 예외가 발생한다.")
+  @ParameterizedTest(name = "plainText: {0}")
+  @MethodSource("plainTexts")
+  void testRsaEncodeWithPublicKey(String plainText) {
+    //given
+    RsaKey rsaKey = rsaKeyUtil.generateRsaKey();
+    String privateKey = rsaKey.privateKey();
+
+    // when, then
+    assertThatThrownBy(() -> rsaKeyUtil.rsaEncode(plainText, privateKey))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @DisplayName("다른 Public Key 로 암호화된 문자열을 복호화하면 예외가 발생한다.")
+  @ParameterizedTest(name = "plainText: {0}")
+  @MethodSource("plainTexts")
+  void testRsaDecodeFromAnotherPublicKey(String plainText) {
+    //given
+    RsaKey originRsaKey = rsaKeyUtil.generateRsaKey();
+    String originPrivateKey = originRsaKey.privateKey();
+
+    RsaKey anotherRsaKey = rsaKeyUtil.generateRsaKey();
+    String anotherPublicKey = anotherRsaKey.publicKey();
+
+    // when
+    String encryptedText = rsaKeyUtil.rsaEncode(plainText, anotherPublicKey);
+
+    // when, then
+    assertThatThrownBy(() -> rsaKeyUtil.rsaDecode(encryptedText, originPrivateKey))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @DisplayName("잘못된 Private Key 로 복호화하면 예외가 발생한다.")
+  @ParameterizedTest(name = "invalidPrivateKey: {0}")
+  @MethodSource("invalidPrivateKeys")
+  void testRsaDecodeWithInvalidPrivateKey(String plainText) {
+    //given
+    RsaKey rsaKey = rsaKeyUtil.generateRsaKey();
+    String publicKey = rsaKey.publicKey();
+
+    // when
+    String encryptedText = rsaKeyUtil.rsaEncode(plainText, publicKey);
+
+    // when, then
+    assertThatThrownBy(() -> rsaKeyUtil.rsaDecode(encryptedText, "invalidPrivateKey"))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @DisplayName("Private Key 가 null 이면 예외가 발생한다.")
+  @Test
+  void testRsaDecodeWithNullPrivateKey() {
+    //given
+    RsaKey rsaKey = rsaKeyUtil.generateRsaKey();
+    String publicKey = rsaKey.publicKey();
+
+    // when
+    String encryptedText = rsaKeyUtil.rsaEncode("plainText", publicKey);
+
+    // when, then
+    assertThatThrownBy(() -> rsaKeyUtil.rsaDecode(encryptedText, null))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @DisplayName("Plain Text 가 null 이면 예외가 발생한다.")
+  @Test
+  void testRsaEncodeWithNullPlainText() {
+    //given
+    RsaKey rsaKey = rsaKeyUtil.generateRsaKey();
+    String publicKey = rsaKey.publicKey();
+
+    // when, then
+    assertThatThrownBy(() -> rsaKeyUtil.rsaEncode(null, publicKey))
+        .isInstanceOf(RuntimeException.class);
+  }
+}

--- a/src/test/java/org/mju_likelion/festival/common/annotation/ApplicationTest.java
+++ b/src/test/java/org/mju_likelion/festival/common/annotation/ApplicationTest.java
@@ -1,0 +1,15 @@
+package org.mju_likelion.festival.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public @interface ApplicationTest {
+
+}


### PR DESCRIPTION
## Description

### 설계 배경
클라이언트(학생회)의 보안을 크게 신경써달라는 요청 반영을 위해 로그인 시스템을 새롭게 설계.

사용자로부터 학교 행정 시스템의 실제 ID와 비밀번호를 입력받아, 학교 행정 시스템과 API 통신을 통해 로그인을 처리하는 방식.
브라우저의 개발자 도구 네트워크 로그의 페이로드(payload)에서 학생의 ID와 비밀번호가 그대로 노출되는 문제발생.
HTTPS를 사용하여 네트워크 전송 구간에서 암호화는 이루어졌지만, 전송 이전의 단계에서는 암호화가 이루어지지 않았기 때문.

서비스 특성 상 학교 내에서 접속하는 경우가 많으므로, 사회공학적 해킹 시도 가능성 존재. (화장실 간 사이 네트워크 탭에서 비밀번호 탈취)

사용자의 학생정보시스템 정보 탈취 가능성을 원천 차단하기 위해 API 전송 전 암호화 아키텍처를 구현.

### 아키텍처
Redis와 Token 방식 채용

### 기본적으로 Redis 를 사용해 Private Key 저장
### Redis 장애 시 Private Key와 만료 시간을 저장하고 있는 Token 사용

<img width="1999" height="2817" alt="image" src="https://github.com/user-attachments/assets/4057fbfe-d7f8-4d2f-86c1-d60052423aa2" />

Redis 장애 여부는 10 초마다 Ping 을 통해 체크

Private Key를 관리하는 클래스(Redis, Token) 를 Redis 장애 여부에 따라 Runtime에 동적으로 교체하기 위한 Context 클래스 사용

## Changes
### RsaKey 객체 - public key와 private key 문자열을 보관
- [x] RsaKey
### RsaKeyStrategy - Rsa Key 관리 전략
- [x] RsaKeyStrategy
### RsaKeyUtil - Rsa Key 생성, 암/복호화
- [x] RsaKeyUtil
### RsaKeyManager - Rsa Key 관리자
- [x] RsaKeyManager
- [x] RedisRsaKeyManager
- [x] TokenRsaKeyManager
### 대칭키 암호화 Util
- [x] EncryptionUtil
### Token 관련 클래스
- [x] CredentialToken
- [x] CredentialTokenUtil
### Redis 관련 클래스
- [x] RedisConfig
- [x] RedisUtil
- [x] RedisAvailabilityChecker
### Exception 관련 클래스
- [x] ErrorType
- [x] ExceptionController
- [x] ErrorResponse
- [x] CustomException & etc...

### Test
- [x] EncryptionUtilTest
- [x] RsaKeyUtilTest

### API
| URL                     | method | Usage                   | Authorization Needed |
| ------------------ | ---------| -------------------- | ------------------------ |
|        /auth/key                    |     GET          |        암호화 Key 정보 요청                       |        X                            |

## Additional context
Closes #10 