### PR TITLE
Feature/#16 유저 로그인 API 개발

### DIFF
--- a/.github/workflows/ci-cd-develop.yml
+++ b/.github/workflows/ci-cd-develop.yml
@@ -40,6 +40,15 @@ jobs:
           echo "${{ secrets.DEV_PROPERTIES }}" > ./application.properties
         shell: bash
 
+      # 2-1. test 용 application.properties 파일 생성
+      - name: make application.properties for test
+        run: |
+          mkdir -p ./src/test/resources
+          cd ./src/test/resources
+          touch ./application.properties
+          echo "${{ secrets.DEV_TEST_PROPERTIES }}" > ./application.properties
+          shell: bash
+
       # 3. Spring Boot 애플리케이션 빌드
       - name: Build with Gradle
         uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,10 @@ jobs:
       # 2. application.properties 파일 생성
       - name: make application.properties
         run: |
-          mkdir -p ./src/main/resources
-          cd ./src/main/resources
+          mkdir -p ./src/test/resources
+          cd ./src/test/resources
           touch ./application.properties
-          echo "${{ secrets.DEV_PROPERTIES }}" > ./application.properties
+          echo "${{ secrets.DEV_TEST_PROPERTIES }}" > ./application.properties
         shell: bash
 
         # Gradle Test를 실행한다

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ replay_pid*
 
 # application.properties
 **/main/resources/application.properties
+**/test/resources/application.properties

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'//JDBC
     runtimeOnly 'com.mysql:mysql-connector-j'//MySQL
 
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'//JWT
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'//JWT
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'//JWT
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'//JAXB
+
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'//Redis
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/org/mju_likelion/festival/auth/controller/AuthController.java
+++ b/src/main/java/org/mju_likelion/festival/auth/controller/AuthController.java
@@ -1,10 +1,17 @@
 package org.mju_likelion.festival.auth.controller;
 
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.auth.domain.RsaKeyStrategy;
+import org.mju_likelion.festival.auth.dto.request.UserLoginRequest;
 import org.mju_likelion.festival.auth.dto.response.KeyResponse;
+import org.mju_likelion.festival.auth.dto.response.LoginResponse;
 import org.mju_likelion.festival.auth.service.AuthService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -16,5 +23,11 @@ public class AuthController {
   @GetMapping("/auth/key")
   public ResponseEntity<KeyResponse> getKey() {
     return ResponseEntity.ok(authService.getKey());
+  }
+
+  @PostMapping("/auth/user/login")
+  public ResponseEntity<LoginResponse> login(@RequestBody @Valid UserLoginRequest userLoginRequest,
+      @RequestParam RsaKeyStrategy rsaKeyStrategy) {
+    return ResponseEntity.ok(authService.userLogin(userLoginRequest, rsaKeyStrategy));
   }
 }

--- a/src/main/java/org/mju_likelion/festival/auth/dto/request/UserLoginRequest.java
+++ b/src/main/java/org/mju_likelion/festival/auth/dto/request/UserLoginRequest.java
@@ -1,0 +1,25 @@
+package org.mju_likelion.festival.auth.dto.request;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserLoginRequest {
+
+  @NotNull(message = "학번이 누락되었습니다.")
+  private String encryptedStudentId;
+
+  @NotNull(message = "비밀번호가 누락되었습니다.")
+  private String encryptedPassword;
+
+  @NotNull(message = "키가 누락되었습니다.")
+  private String key;
+
+  @NotNull(message = "동의 항목이 누락되었습니다.")
+  private Map<UUID, @AssertTrue(message = "동의 항목에 동의해야 합니다.") Boolean> terms;
+}

--- a/src/main/java/org/mju_likelion/festival/auth/dto/response/LoginResponse.java
+++ b/src/main/java/org/mju_likelion/festival/auth/dto/response/LoginResponse.java
@@ -1,0 +1,11 @@
+package org.mju_likelion.festival.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+
+  private final String accessToken;
+}

--- a/src/main/java/org/mju_likelion/festival/auth/service/AuthService.java
+++ b/src/main/java/org/mju_likelion/festival/auth/service/AuthService.java
@@ -1,11 +1,29 @@
 package org.mju_likelion.festival.auth.service;
 
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import org.mju_likelion.festival.auth.domain.RsaKey;
 import org.mju_likelion.festival.auth.domain.RsaKeyStrategy;
+import org.mju_likelion.festival.auth.dto.request.UserLoginRequest;
 import org.mju_likelion.festival.auth.dto.response.KeyResponse;
+import org.mju_likelion.festival.auth.dto.response.LoginResponse;
+import org.mju_likelion.festival.auth.util.jwt.JwtUtil;
 import org.mju_likelion.festival.auth.util.key.manager.RsaKeyManager;
 import org.mju_likelion.festival.auth.util.key.manager.RsaKeyManagerContext;
+import org.mju_likelion.festival.common.exception.BadRequestException;
+import org.mju_likelion.festival.common.exception.UnauthorizedException;
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.mju_likelion.festival.common.util.api.MjuApiUtil;
+import org.mju_likelion.festival.term.domain.Term;
+import org.mju_likelion.festival.term.domain.repository.TermJpaRepository;
+import org.mju_likelion.festival.user.domain.User;
+import org.mju_likelion.festival.user.domain.repository.UserJpaRepository;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,6 +31,10 @@ import org.springframework.stereotype.Service;
 public class AuthService {
 
   private final RsaKeyManagerContext rsaKeyManagerContext;
+  private final MjuApiUtil mjuApiUtil;
+  private final UserJpaRepository userJpaRepository;
+  private final TermJpaRepository termJpaRepository;
+  private final JwtUtil jwtUtil;
 
   public KeyResponse getKey() {
     RsaKeyManager rsaKeyManager = rsaKeyManager();
@@ -24,6 +46,96 @@ public class AuthService {
     RsaKeyStrategy rsaKeyStrategy = rsaKeyManager.rsaKeyStrategy();
 
     return new KeyResponse(rsaKey.publicKey(), credentialKey, rsaKeyStrategy);
+  }
+
+  @Transactional
+  public LoginResponse userLogin(UserLoginRequest userLoginRequest, RsaKeyStrategy rsaKeyStrategy) {
+    RsaKeyManager rsaKeyManager = rsaKeyManager(rsaKeyStrategy);
+
+    String key = userLoginRequest.getKey();
+    String studentId = rsaKeyManager.decryptByKey(userLoginRequest.getEncryptedStudentId(), key);
+    String password = rsaKeyManager.decryptByKey(userLoginRequest.getEncryptedPassword(), key);
+
+    validateUser(studentId, password);
+
+    UUID userId = saveOrGetUserId(studentId, userLoginRequest.getTerms());
+
+    String accessToken = jwtUtil.create(userId.toString());
+    return new LoginResponse(accessToken);
+  }
+
+  /**
+   * 사용자가 동의한 약관을 저장하고, 사용자의 ID를 반환한다.
+   * <p>
+   * 사용자가 이미 존재하는 경우, 사용자의 ID를 반환한다.
+   *
+   * @param studentId 학번
+   * @param terms     사용자가 동의한 약관
+   * @return 사용자의 ID
+   */
+  private UUID saveOrGetUserId(String studentId, Map<UUID, Boolean> terms) {
+    Optional<UUID> userId = userJpaRepository.findIdByStudentId(studentId);
+
+    if (userId.isPresent()) {
+      return userId.get();
+    }
+
+    List<Term> validTerms = getValidTerms(terms.keySet());
+    return saveUser(studentId, validTerms);
+  }
+
+  /**
+   * 사용자를 저장하고, 사용자의 ID를 반환한다.
+   *
+   * @param studentId 학번
+   * @param terms     사용자가 동의한 약관
+   * @return 사용자의 ID
+   */
+  private UUID saveUser(String studentId, List<Term> terms) {
+    User user = new User(studentId);
+
+    terms.forEach(user::agreeToTerm);
+
+    userJpaRepository.save(user);
+
+    return user.getId();
+  }
+
+  /**
+   * 약관 ID 목록을 이용하여 유효한 약관 목록을 반환한다.
+   *
+   * @param termIds 약관 ID 목록
+   * @return 유효한 약관 목록
+   */
+  private List<Term> getValidTerms(Set<UUID> termIds) {
+    List<Term> terms = termJpaRepository.findAll();
+    validateTermIds(terms, termIds);
+    return terms;
+  }
+
+  /**
+   * 약관 ID 목록이 유효한지 검증한다.
+   *
+   * @param termsInDb DB 의 약관 목록
+   * @param termIds   약관 ID 목록
+   */
+  private void validateTermIds(List<Term> termsInDb, Set<UUID> termIds) {
+    Set<UUID> validTermIds = termsInDb.stream().map(Term::getId).collect(Collectors.toSet());
+    if (!validTermIds.containsAll(termIds)) {
+      throw new BadRequestException(ErrorType.MISSING_TERM);
+    }
+  }
+
+  /**
+   * 사용자의 학번과 비밀번호를 검증한다. 명지대학교 MSI API 를 이용하여 사용자의 존재 여부를 확인한다.
+   *
+   * @param studentId 학번
+   * @param password  비밀번호
+   */
+  private void validateUser(String studentId, String password) {
+    if (!mjuApiUtil.doUserCheck(studentId, password)) {
+      throw new UnauthorizedException(ErrorType.INVALID_CREDENTIALS);
+    }
   }
 
   private RsaKeyManager rsaKeyManager() {

--- a/src/main/java/org/mju_likelion/festival/auth/util/jwt/JwtUtil.java
+++ b/src/main/java/org/mju_likelion/festival/auth/util/jwt/JwtUtil.java
@@ -1,0 +1,51 @@
+package org.mju_likelion.festival.auth.util.jwt;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.mju_likelion.festival.common.exception.UnauthorizedException;
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtUtil {
+
+  private final SecretKey key;
+  private final long validityInMilliseconds;
+
+  public JwtUtil(@Value("${security.jwt.token.secret-key}") final String secretKey,
+      @Value("${security.jwt.token.expire-length}") final long validityInMilliseconds) {
+    this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    this.validityInMilliseconds = validityInMilliseconds;
+  }
+
+  public String create(final String payload) {
+    Date now = new Date();
+    Date expiration = new Date(now.getTime() + validityInMilliseconds);
+
+    return Jwts.builder()
+        .setSubject(payload)
+        .setIssuedAt(now)
+        .setExpiration(expiration)
+        .signWith(key, SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  public String getPayload(final String token) {
+    try {
+      return Jwts.parserBuilder()
+          .setSigningKey(key)
+          .build()
+          .parseClaimsJws(token)
+          .getBody()
+          .getSubject();
+    } catch (JwtException e) {
+      throw new UnauthorizedException(ErrorType.INVALID_JWT, e.getLocalizedMessage());
+    }
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/auth/util/key/manager/RsaKeyManager.java
+++ b/src/main/java/org/mju_likelion/festival/auth/util/key/manager/RsaKeyManager.java
@@ -25,7 +25,7 @@ public interface RsaKeyManager {
   String savePrivateKey(String privateKey);
 
   /**
-   * RSA Private Key 를 이용하여 암호화된 텍스트를 복호화한다.
+   * Key 를 이용하여 암호화된 텍스트를 복호화한다.
    *
    * @param plainText 암호화된 텍스트
    * @param key       RSA Private Key 를 식별할 수 있는 Key

--- a/src/main/java/org/mju_likelion/festival/auth/util/key/manager/TokenRsaKeyManager.java
+++ b/src/main/java/org/mju_likelion/festival/auth/util/key/manager/TokenRsaKeyManager.java
@@ -25,9 +25,9 @@ public class TokenRsaKeyManager implements RsaKeyManager {
   }
 
   @Override
-  public String decryptByKey(String plainText, String key) {
+  public String decryptByKey(String encryptedText, String key) {
     String privateKey = credentialTokenUtil.parsePrivateKey(key);
-    return rsaKeyUtil.rsaDecode(plainText, privateKey);
+    return rsaKeyUtil.rsaDecode(encryptedText, privateKey);
   }
 
   @Override

--- a/src/main/java/org/mju_likelion/festival/common/config/WebConfig.java
+++ b/src/main/java/org/mju_likelion/festival/common/config/WebConfig.java
@@ -1,0 +1,14 @@
+package org.mju_likelion.festival.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class WebConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/domain/BaseEntity.java
+++ b/src/main/java/org/mju_likelion/festival/common/domain/BaseEntity.java
@@ -21,28 +21,11 @@ public abstract class BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "uuid2")
   @Column(name = "id", updatable = false, unique = true, nullable = false)
-  private UUID id;
+  protected UUID id;
 
   @CreatedDate
   private LocalDateTime createdAt;
 
   @LastModifiedDate
   private LocalDateTime updatedAt;
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    BaseEntity that = (BaseEntity) o;
-    return id.equals(that.id);
-  }
-
-  @Override
-  public int hashCode() {
-    return id.hashCode();
-  }
 }

--- a/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
@@ -11,8 +11,16 @@ public enum ErrorType {
   DECRYPT_ERROR(1001, "복호화에 실패했습니다."),
   RSA_KEY_ERROR(1002, "RSA 키 처리 중 오류가 발생했습니다."),
   CREDENTIAL_TOKEN_EXPIRED(1003, "자격 증명 토큰이 만료되었습니다."),
+  CREDENTIAL_KEY_INVALID(1004, "자격 증명 키가 유효하지 않습니다."),
 
   INVALID_REQUEST_BODY(4000, "요청 바디가 잘못되었습니다."),
+
+  INVALID_CREDENTIALS(4010, "아이디나 비밀번호가 일치하지 않습니다."),
+
+  MISSING_TERM(4040, "동의 항목이 누락되었습니다."),
+
+  INVALID_JWT(5000, "JWT 토큰이 유효하지 않습니다."),
+  API_ERROR(5001, "API 호출 중 오류가 발생했습니다."),
 
   REDIS_ERROR(6000, "Redis 에러가 발생했습니다.");
 

--- a/src/main/java/org/mju_likelion/festival/common/util/api/ApiResponse.java
+++ b/src/main/java/org/mju_likelion/festival/common/util/api/ApiResponse.java
@@ -1,0 +1,10 @@
+package org.mju_likelion.festival.common.util.api;
+
+import lombok.Getter;
+
+@Getter
+public class ApiResponse {
+
+  private String error;
+  private String errorMessage;
+}

--- a/src/main/java/org/mju_likelion/festival/common/util/api/MjuApiUtil.java
+++ b/src/main/java/org/mju_likelion/festival/common/util/api/MjuApiUtil.java
@@ -1,0 +1,50 @@
+package org.mju_likelion.festival.common.util.api;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.API_ERROR;
+
+import lombok.RequiredArgsConstructor;
+import org.mju_likelion.festival.common.exception.InternalServerException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class MjuApiUtil {
+
+  private final RestTemplate restTemplate;
+
+  @Value("${mju-user-check-api-uri}")
+  private String mjuUserCheckApiUri;
+
+  public boolean doUserCheck(String studentId, String password) {
+    try {
+      HttpHeaders headers = new HttpHeaders();
+      headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+      MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+      body.add("id", studentId);
+      body.add("passwrd", password);
+
+      HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+      ResponseEntity<ApiResponse> responseEntity = restTemplate.postForEntity(mjuUserCheckApiUri,
+          request, ApiResponse.class);
+
+      ApiResponse response = responseEntity.getBody();
+      if (response != null) {
+        return "0000".equals(response.getError());
+      }
+
+      throw new InternalServerException(API_ERROR, "Response body is null");
+    } catch (Exception e) {
+      throw new InternalServerException(API_ERROR, e.getMessage());
+    }
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/util/redis/RedisUtil.java
+++ b/src/main/java/org/mju_likelion/festival/common/util/redis/RedisUtil.java
@@ -32,4 +32,12 @@ public class RedisUtil<K, V> {
       throw new InternalServerException(REDIS_ERROR, e.getMessage());
     }
   }
+
+  public void delete(K key) {
+    try {
+      this.redisTemplate.delete(key);
+    } catch (Exception e) {
+      throw new InternalServerException(REDIS_ERROR, e.getMessage());
+    }
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/term/domain/Term.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/Term.java
@@ -3,12 +3,9 @@ package org.mju_likelion.festival.term.domain;
 import static org.mju_likelion.festival.common.domain.constant.ColumnLengths.TERM_CONTENT_LENGTH;
 import static org.mju_likelion.festival.common.domain.constant.ColumnLengths.TERM_TITLE_LENGTH;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.OneToMany;
-import java.util.List;
+import java.util.Objects;
 import lombok.Getter;
 import org.mju_likelion.festival.common.domain.BaseEntity;
 
@@ -22,6 +19,27 @@ public class Term extends BaseEntity {
   @Column(nullable = false, length = TERM_CONTENT_LENGTH)
   private String content;
 
-  @OneToMany(mappedBy = "term", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
-  private List<TermUser> termUsers;
+  @Override
+  public String toString() {
+    return "Term{" +
+        "title='" + title + '\'' +
+        ", content='" + content + '\'' +
+        '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Term term)) {
+      return false;
+    }
+    return this.id.equals(term.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/term/domain/TermUser.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/TermUser.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import org.mju_likelion.festival.user.domain.User;
 
 @Getter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity(name = "term_user")
 public class TermUser extends BaseEntity {
@@ -25,4 +26,28 @@ public class TermUser extends BaseEntity {
   @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "term_id", nullable = false)
   private Term term;
+
+  @Override
+  public String toString() {
+    return "TermUser{" +
+        "user=" + user +
+        ", term=" + term +
+        '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TermUser termUser)) {
+      return false;
+    }
+    return user.equals(termUser.user) && term.equals(termUser.term);
+  }
+
+  @Override
+  public int hashCode() {
+    return user.hashCode() + term.hashCode();
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/term/domain/TermUsers.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/TermUsers.java
@@ -1,0 +1,24 @@
+package org.mju_likelion.festival.term.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
+import java.util.HashSet;
+import java.util.Set;
+import org.mju_likelion.festival.user.domain.User;
+
+@Embeddable
+public class TermUsers {
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  private Set<TermUser> termUsers = new HashSet<>();
+
+  public void agree(Term term, User user) {
+    TermUser termUser = TermUser.builder()
+        .term(term)
+        .user(user)
+        .build();
+    this.termUsers.add(termUser);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/user/domain/User.java
+++ b/src/main/java/org/mju_likelion/festival/user/domain/User.java
@@ -4,31 +4,65 @@ import static org.mju_likelion.festival.common.domain.constant.ColumnLengths.USE
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import java.util.Objects;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.mju_likelion.festival.booth.domain.BoothUser;
 import org.mju_likelion.festival.common.domain.BaseEntity;
-import org.mju_likelion.festival.term.domain.TermUser;
+import org.mju_likelion.festival.term.domain.Term;
+import org.mju_likelion.festival.term.domain.TermUsers;
 
 @Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "user")
 public class User extends BaseEntity {
 
   @Column(name = "student_id", nullable = false, unique = true, length = USER_STUDENT_ID_LENGTH)
   private String studentId;
 
-  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-  private List<TermUser> termUsers;
+  @Embedded
+  private TermUsers termUsers;
 
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
   private List<BoothUser> boothUsers;
+
+  public User(String studentId) {
+    this.studentId = studentId;
+    this.termUsers = new TermUsers();
+    this.boothUsers = new ArrayList<>();
+  }
+
+  public void agreeToTerm(Term term) {
+    this.termUsers.agree(term, this);
+  }
+
+  @Override
+  public String toString() {
+    return "User{" +
+        "studentId='" + studentId + '\'' +
+        '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof User user)) {
+      return false;
+    }
+    return this.id.equals(user.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.id);
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/user/domain/repository/UserJpaRepository.java
+++ b/src/main/java/org/mju_likelion/festival/user/domain/repository/UserJpaRepository.java
@@ -1,11 +1,16 @@
 package org.mju_likelion.festival.user.domain.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.Optional;
 import java.util.UUID;
 import org.mju_likelion.festival.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserJpaRepository extends JpaRepository<User, UUID> {
 
+  @Query("SELECT u.id FROM user u WHERE u.studentId = :studentId")
+  Optional<UUID> findIdByStudentId(@Param("studentId") String studentId);
 }

--- a/src/test/java/org/mju_likelion/festival/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/mju_likelion/festival/auth/service/AuthServiceTest.java
@@ -1,0 +1,102 @@
+package org.mju_likelion.festival.auth.service;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.mockito.BDDMockito.willReturn;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mju_likelion.festival.auth.domain.RsaKeyStrategy;
+import org.mju_likelion.festival.auth.dto.request.UserLoginRequest;
+import org.mju_likelion.festival.auth.dto.response.KeyResponse;
+import org.mju_likelion.festival.auth.dto.response.LoginResponse;
+import org.mju_likelion.festival.auth.util.key.RsaKeyUtil;
+import org.mju_likelion.festival.auth.util.key.manager.RedisRsaKeyManager;
+import org.mju_likelion.festival.auth.util.key.manager.RsaKeyManagerContext;
+import org.mju_likelion.festival.auth.util.key.manager.TokenRsaKeyManager;
+import org.mju_likelion.festival.common.annotation.ApplicationTest;
+import org.mju_likelion.festival.term.domain.Term;
+import org.mju_likelion.festival.term.domain.repository.TermJpaRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@DisplayName("AuthService")
+@ApplicationTest
+public class AuthServiceTest {
+
+  @Value("${student-id}")
+  private String studentId;
+  @Value("${student-password}")
+  private String studentPassword;
+  @Autowired
+  private AuthService authService;
+  @MockBean
+  private RsaKeyManagerContext rsaKeyManagerContext;
+  @Autowired
+  private RsaKeyUtil rsaKeyUtil;
+  @Autowired
+  private RedisRsaKeyManager redisRsaKeyManager;
+  @Autowired
+  private TokenRsaKeyManager tokenRsaKeyManager;
+  @Autowired
+  private TermJpaRepository termJpaRepository;
+
+
+  @DisplayName("RedisRsaKeyManager 를 사용하여 암호화된 studentId, password, key를 받아 로그인한다.")
+  @Test
+  void testUserLogin() {
+    // given
+    willReturn(redisRsaKeyManager).given(rsaKeyManagerContext).rsaKeyManager();
+    willReturn(redisRsaKeyManager).given(rsaKeyManagerContext).rsaKeyManager(RsaKeyStrategy.REDIS);
+    KeyResponse keyResponse = authService.getKey();
+    UserLoginRequest userLoginRequest = createUserLoginRequest(keyResponse);
+
+    // when
+    LoginResponse loginResponse = authService.userLogin(userLoginRequest,
+        RsaKeyStrategy.REDIS);
+
+    // then
+    assertNotNull(loginResponse.getAccessToken());
+  }
+
+  @DisplayName("TokenRsaKeyManager 를 사용하여 암호화된 studentId, password, key를 받아 로그인한다.")
+  @Test
+  void testUserLoginWithTokenRsaKeyManager() {
+    // given
+    willReturn(tokenRsaKeyManager).given(rsaKeyManagerContext).rsaKeyManager();
+    willReturn(tokenRsaKeyManager).given(rsaKeyManagerContext).rsaKeyManager(RsaKeyStrategy.TOKEN);
+    KeyResponse keyResponse = authService.getKey();
+    UserLoginRequest userLoginRequest = createUserLoginRequest(keyResponse);
+
+    // when
+    LoginResponse loginResponse = authService.userLogin(userLoginRequest,
+        RsaKeyStrategy.TOKEN);
+
+    // then
+    assertNotNull(loginResponse.getAccessToken());
+  }
+
+  /**
+   * UserLoginRequest 객체를 생성한다.
+   *
+   * @param keyResponse 키 응답 객체
+   * @return UserLoginRequest 객체
+   */
+  private UserLoginRequest createUserLoginRequest(KeyResponse keyResponse) {
+    String publicKey = keyResponse.getRsaPublicKey();
+    String credentialKey = keyResponse.getCredentialKey();
+
+    String encryptedStudentId = rsaKeyUtil.rsaEncode(studentId, publicKey);
+    String encryptedPassword = rsaKeyUtil.rsaEncode(studentPassword, publicKey);
+
+    List<Term> terms = termJpaRepository.findAll();
+    HashMap<UUID, Boolean> termMap = new HashMap<>();
+    terms.forEach(term -> termMap.put(term.getId(), true));
+
+    return new UserLoginRequest(encryptedStudentId, encryptedPassword,
+        credentialKey, termMap);
+  }
+}


### PR DESCRIPTION
## Description
유저 로그인 API 개발

암호화된 id, pw를 통해 MSI에서 조회
## Changes
### MSI API 요청
- [x] WebConfig
- [x] MjuApiUtil
- [x] ApiResponse
### Jwt Util 클래스
- [x] JwtUtil
### RsaKeyManager 리팩터링
- [x] RedisRsaKeyManager에서 복호화 후 Private Key 제거하도록
### BaseEntity equals, hashCode 제거, 자식클래스에서 구현
- [x] BaseEntity
- [x] User
- [x] Term
- [x] TermUser
### User의 List<TermUser> 일급 컬렉션으로 포장
- [x] User
- [x] TermUsers
- [x] Term
### Test 용 properties 추가
- [x] /src/test/resources/application.properties
- [x] .gitignore
- [x] test.yml
- [x] ci-cd-develop.yml

### API
| URL                     | method | Usage                   | Authorization Needed |
| ------------------ | ---------| -------------------- | ------------------------ |
|              /auth/user/login              |     POST          |        유저 로그인                       |           X                         |

## Additional context
API 요청 시 RestTemplate 사용
WebClient와 RestTemplate 중 고민했음

### RestTemplate 장점
- 설정이 간편, 사용 편함, 직관적
### RestTemplate 단점
- 동기적 Http 요청을 수행 
- 이로 인해 처리 시간이 오래 걸리고 대규모 트래픽에서 적절하지 않을 수 있음

### WebClient 장점
- 비동기 Non-Blocking 방식 사용 -> 빠름
- 비동기 방식으로 인해 더 나은 성능과 리소스 사용 효율을 제공함.
### WebClient 단점
- Webflux 모듈이 통째로 추가됨 -> 가벼운 Application에서 굳이 필요 없음
- Webflux 학습곡선 존재 -> 빠른 적용 힘듦

### 의사결정 근거
- API 요청의 목적은 사용자가 MSI 상에 존재 여부를 판단하는 것임.
- MSI 존재 여부를 판단한 후, 다음 로직이 수행되어야 함.
- 따라서, 이 과정은 동기/Blocking-IO 방식으로 수행되어야 함.
- 그러므로, RestTemplate을 사용하기로 결정함.

Closes #16 