### PR TITLE
Feature/#18 관리자 로그인 API 개발

### DIFF
--- a/src/main/java/org/mju_likelion/festival/admin/domain/repository/AdminJpaRepository.java
+++ b/src/main/java/org/mju_likelion/festival/admin/domain/repository/AdminJpaRepository.java
@@ -1,5 +1,6 @@
 package org.mju_likelion.festival.admin.domain.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 import org.mju_likelion.festival.admin.domain.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AdminJpaRepository extends JpaRepository<Admin, UUID> {
 
+  Optional<Admin> findByLoginIdAndPassword(String loginId, String password);
 }

--- a/src/main/java/org/mju_likelion/festival/auth/controller/AuthController.java
+++ b/src/main/java/org/mju_likelion/festival/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package org.mju_likelion.festival.auth.controller;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.mju_likelion.festival.auth.domain.RsaKeyStrategy;
+import org.mju_likelion.festival.auth.dto.request.AdminLoginRequest;
 import org.mju_likelion.festival.auth.dto.request.UserLoginRequest;
 import org.mju_likelion.festival.auth.dto.response.KeyResponse;
 import org.mju_likelion.festival.auth.dto.response.LoginResponse;
@@ -26,8 +27,16 @@ public class AuthController {
   }
 
   @PostMapping("/auth/user/login")
-  public ResponseEntity<LoginResponse> login(@RequestBody @Valid UserLoginRequest userLoginRequest,
+  public ResponseEntity<LoginResponse> userLogin(
+      @RequestBody @Valid UserLoginRequest userLoginRequest,
       @RequestParam RsaKeyStrategy rsaKeyStrategy) {
     return ResponseEntity.ok(authService.userLogin(userLoginRequest, rsaKeyStrategy));
+  }
+
+  @PostMapping("/auth/admin/login")
+  public ResponseEntity<LoginResponse> adminLogin(
+      @RequestBody @Valid AdminLoginRequest adminLoginRequest,
+      @RequestParam RsaKeyStrategy rsaKeyStrategy) {
+    return ResponseEntity.ok(authService.adminLogin(adminLoginRequest, rsaKeyStrategy));
   }
 }

--- a/src/main/java/org/mju_likelion/festival/auth/controller/AuthController.java
+++ b/src/main/java/org/mju_likelion/festival/auth/controller/AuthController.java
@@ -12,28 +12,30 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @AllArgsConstructor
+@RequestMapping("/auth")
 public class AuthController {
 
   private final AuthService authService;
 
-  @GetMapping("/auth/key")
+  @GetMapping("/key")
   public ResponseEntity<KeyResponse> getKey() {
     return ResponseEntity.ok(authService.getKey());
   }
 
-  @PostMapping("/auth/user/login")
+  @PostMapping("/user/login")
   public ResponseEntity<LoginResponse> userLogin(
       @RequestBody @Valid UserLoginRequest userLoginRequest,
       @RequestParam RsaKeyStrategy rsaKeyStrategy) {
     return ResponseEntity.ok(authService.userLogin(userLoginRequest, rsaKeyStrategy));
   }
 
-  @PostMapping("/auth/admin/login")
+  @PostMapping("/admin/login")
   public ResponseEntity<LoginResponse> adminLogin(
       @RequestBody @Valid AdminLoginRequest adminLoginRequest,
       @RequestParam RsaKeyStrategy rsaKeyStrategy) {

--- a/src/main/java/org/mju_likelion/festival/auth/dto/request/AdminLoginRequest.java
+++ b/src/main/java/org/mju_likelion/festival/auth/dto/request/AdminLoginRequest.java
@@ -1,0 +1,17 @@
+package org.mju_likelion.festival.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class AdminLoginRequest {
+
+  @NotBlank(message = "관리자 아이디가 누락되었습니다.")
+  private String encryptedLoginId;
+
+  @NotBlank(message = "비밀번호가 누락되었습니다.")
+  private String encryptedPassword;
+
+  @NotBlank(message = "키가 누락되었습니다.")
+  private String key;
+}

--- a/src/main/java/org/mju_likelion/festival/auth/dto/request/AdminLoginRequest.java
+++ b/src/main/java/org/mju_likelion/festival/auth/dto/request/AdminLoginRequest.java
@@ -1,9 +1,11 @@
 package org.mju_likelion.festival.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class AdminLoginRequest {
 
   @NotBlank(message = "관리자 아이디가 누락되었습니다.")

--- a/src/main/java/org/mju_likelion/festival/auth/dto/request/UserLoginRequest.java
+++ b/src/main/java/org/mju_likelion/festival/auth/dto/request/UserLoginRequest.java
@@ -5,9 +5,11 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class UserLoginRequest {
 
   @NotBlank(message = "학번이 누락되었습니다.")

--- a/src/main/java/org/mju_likelion/festival/auth/dto/request/UserLoginRequest.java
+++ b/src/main/java/org/mju_likelion/festival/auth/dto/request/UserLoginRequest.java
@@ -1,23 +1,22 @@
 package org.mju_likelion.festival.auth.dto.request;
 
 import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class UserLoginRequest {
 
-  @NotNull(message = "학번이 누락되었습니다.")
+  @NotBlank(message = "학번이 누락되었습니다.")
   private String encryptedStudentId;
 
-  @NotNull(message = "비밀번호가 누락되었습니다.")
+  @NotBlank(message = "비밀번호가 누락되었습니다.")
   private String encryptedPassword;
 
-  @NotNull(message = "키가 누락되었습니다.")
+  @NotBlank(message = "키가 누락되었습니다.")
   private String key;
 
   @NotNull(message = "동의 항목이 누락되었습니다.")


### PR DESCRIPTION
## Description
관리자 로그인 API 개발

관리자는 loginId, password를 사용하여 로그인
## Changes
### 관리자 로그인 DTO
- [x] AdminLoginRequest
### loginId, password로 Admin 을 찾는 함수 추가
- [x] AdminJpaRepository
### 테스트 코드 작성
- [x] AuthServiceTest

### API
| URL                     | method | Usage                   | Authorization Needed |
| ------------------ | ---------| -------------------- | ------------------------ |
|          /auth/admin/login?rsaKeyStrategy={}                  |       POST        |              관리자 로그인                 |                 X                   |

## Additional context
Closes #18 