### PR TITLE
Feature/#25 기본 예외처리 핸들러 추가

### DIFF
--- a/src/main/java/org/mju_likelion/festival/common/exception/controller/ExceptionController.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/controller/ExceptionController.java
@@ -1,5 +1,7 @@
 package org.mju_likelion.festival.common.exception.controller;
 
+import static org.mju_likelion.festival.common.exception.type.ErrorType.HTTP_MEDIA_TYPE_NOT_SUPPORTED_ERROR;
+
 import lombok.extern.slf4j.Slf4j;
 import org.mju_likelion.festival.common.exception.BadRequestException;
 import org.mju_likelion.festival.common.exception.CustomException;
@@ -7,9 +9,15 @@ import org.mju_likelion.festival.common.exception.dto.ErrorResponse;
 import org.mju_likelion.festival.common.exception.type.ErrorType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -21,6 +29,7 @@ public class ExceptionController {
     return ResponseEntity.status(e.getHttpStatus()).body(ErrorResponse.res(e));
   }
 
+  // MethodArgumentNotValidException 예외를 처리하는 핸들러(요청 바디가 잘못된 경우)
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ErrorResponse> springValidationExceptionHandler(
       final MethodArgumentNotValidException e) {
@@ -31,6 +40,77 @@ public class ExceptionController {
 
     writeLog(badRequestException);
     return ResponseEntity.badRequest().body(ErrorResponse.res(badRequestException));
+  }
+
+  // MissingServletRequestParameterException 예외를 처리하는 핸들러(필수 요청 파라미터가 누락된 경우)
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<ErrorResponse> missingServletRequestParameterExceptionHandler(
+      final MissingServletRequestParameterException e) {
+    BadRequestException badRequestException = new BadRequestException(
+        ErrorType.MISSING_REQUEST_PARAMETER, e.getParameterName());
+
+    writeLog(badRequestException);
+    return ResponseEntity.badRequest().body(ErrorResponse.res(badRequestException));
+  }
+
+  // HttpMessageNotReadableException 예외를 처리하는 핸들러(Body가 잘못된 경우(json 형식이 잘못된 경우))
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+      HttpMessageNotReadableException httpMessageNotReadableException) {
+    BadRequestException badRequestException = new BadRequestException(
+        ErrorType.INVALID_REQUEST_FORMAT_ERROR, httpMessageNotReadableException.getMessage());
+
+    writeLog(badRequestException);
+    return ResponseEntity.badRequest().body(ErrorResponse.res(badRequestException));
+  }
+
+  // HttpRequestMethodNotSupportedException 예외를 처리하는 핸들러(요청의 메소드가 잘못된 경우)
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+      HttpRequestMethodNotSupportedException httpRequestMethodNotSupportedException) {
+    BadRequestException badRequestException = new BadRequestException(
+        ErrorType.METHOD_NOT_ALLOWED_ERROR, httpRequestMethodNotSupportedException.getMessage());
+
+    writeLog(badRequestException);
+    return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+        .body(ErrorResponse.res(badRequestException));
+  }
+
+  // NoResourceFoundException 예외를 처리하는 핸들러(리소스를 찾을 수 없는 경우(URI가 잘못된 경우))
+  @ExceptionHandler(NoResourceFoundException.class)
+  public ResponseEntity<ErrorResponse> handleNoResourceFoundException(
+      NoResourceFoundException noResourceFoundException) {
+    BadRequestException badRequestException = new BadRequestException(
+        ErrorType.NO_RESOURCE_ERROR, noResourceFoundException.getMessage());
+
+    writeLog(badRequestException);
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.res(badRequestException));
+  }
+
+  // HttpMediaTypeNotAcceptableException 예외를 처리하는 핸들러(요청의 Accept 헤더가 잘못된 경우)
+  @ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
+  public ResponseEntity<ErrorResponse> handleHttpMediaTypeNotAcceptableException(
+      HttpMediaTypeNotAcceptableException httpMediaTypeNotAcceptableException) {
+    BadRequestException badRequestException = new BadRequestException(
+        ErrorType.HTTP_MEDIA_TYPE_NOT_ACCEPTABLE_ERROR,
+        httpMediaTypeNotAcceptableException.getMessage());
+
+    writeLog(badRequestException);
+
+    return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+        .body(ErrorResponse.res(badRequestException));
+  }
+
+  // HttpMediaTypeNotSupportedException 예외를 처리하는 핸들러(요청의 Content-Type 헤더가 잘못된 경우)
+  @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+  public ResponseEntity<ErrorResponse> handleHttpMediaTypeNotSupportedException(
+      HttpMediaTypeNotSupportedException httpMediaTypeNotSupportedException) {
+    BadRequestException badRequestException = new BadRequestException(
+        HTTP_MEDIA_TYPE_NOT_SUPPORTED_ERROR, httpMediaTypeNotSupportedException.getMessage());
+
+    writeLog(badRequestException);
+    return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+        .body(ErrorResponse.res(badRequestException));
   }
 
   @ExceptionHandler(Exception.class)

--- a/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
@@ -14,10 +14,19 @@ public enum ErrorType {
   CREDENTIAL_KEY_INVALID(1004, "자격 증명 키가 유효하지 않습니다."),
 
   INVALID_REQUEST_BODY(4000, "요청 바디가 잘못되었습니다."),
+  MISSING_REQUEST_PARAMETER(4001, "필수 요청 파라미터가 누락되었습니다."),
+  INVALID_REQUEST_FORMAT_ERROR(4002, "요청 바디 형식이 잘못되었습니다."),
 
   INVALID_CREDENTIALS(4010, "아이디나 비밀번호가 일치하지 않습니다."),
 
   MISSING_TERM(4040, "동의 항목이 누락되었습니다."),
+  NO_RESOURCE_ERROR(4041, "해당 리소스를 찾을 수 없습니다."),
+
+  METHOD_NOT_ALLOWED_ERROR(4050, "허용되지 않은 HTTP 메소드입니다."),
+
+  HTTP_MEDIA_TYPE_NOT_ACCEPTABLE_ERROR(4060, "수락할 수 없는 미디어 타입입니다."),
+
+  HTTP_MEDIA_TYPE_NOT_SUPPORTED_ERROR(4150, "지원하지 않는 미디어 타입입니다."),
 
   INVALID_JWT(5000, "JWT 토큰이 유효하지 않습니다."),
   API_ERROR(5001, "API 호출 중 오류가 발생했습니다."),


### PR DESCRIPTION
## Description
기본 예외처리 핸들러 추가
## Changes
### ExceptionHandler
- [x] MethodArgumentNotValidException - 요청 바디가 잘못된 경우
- [x] MissingServletRequestParameterException - 필수 요청 파라미터가 누락된 경우
- [x] HttpMessageNotReadableException - Body가 잘못된 경우(json 형식이 잘못된 경우)
- [x] HttpRequestMethodNotSupportedException - 요청의 메소드가 잘못된 경우
- [x] NoResourceFoundException - 리소스를 찾을 수 없는 경우(URI가 잘못된 경우)
- [x] HttpMediaTypeNotAcceptableException - 요청의 Accept 헤더가 잘못된 경우
- [x] HttpMediaTypeNotSupportedException - 요청의 Content-Type 헤더가 잘못된 경우
## Additional context
Closes #25 