### PR TITLE
Feature/#29 동의 항목 조회 API 개발

### DIFF
--- a/src/main/java/org/mju_likelion/festival/auth/controller/AuthController.java
+++ b/src/main/java/org/mju_likelion/festival/auth/controller/AuthController.java
@@ -1,12 +1,14 @@
 package org.mju_likelion.festival.auth.controller;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import org.mju_likelion.festival.auth.domain.RsaKeyStrategy;
 import org.mju_likelion.festival.auth.dto.request.AdminLoginRequest;
 import org.mju_likelion.festival.auth.dto.request.UserLoginRequest;
 import org.mju_likelion.festival.auth.dto.response.KeyResponse;
 import org.mju_likelion.festival.auth.dto.response.LoginResponse;
+import org.mju_likelion.festival.auth.dto.response.TermResponse;
 import org.mju_likelion.festival.auth.service.AuthService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,5 +42,10 @@ public class AuthController {
       @RequestBody @Valid AdminLoginRequest adminLoginRequest,
       @RequestParam RsaKeyStrategy rsaKeyStrategy) {
     return ResponseEntity.ok(authService.adminLogin(adminLoginRequest, rsaKeyStrategy));
+  }
+
+  @GetMapping("/terms")
+  public ResponseEntity<List<TermResponse>> getTerms() {
+    return ResponseEntity.ok(authService.getTerms());
   }
 }

--- a/src/main/java/org/mju_likelion/festival/auth/dto/response/TermResponse.java
+++ b/src/main/java/org/mju_likelion/festival/auth/dto/response/TermResponse.java
@@ -1,0 +1,19 @@
+package org.mju_likelion.festival.auth.dto.response;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.mju_likelion.festival.term.domain.Term;
+
+@Getter
+@AllArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class TermResponse {
+
+  private final UUID id;
+  private final String title;
+  private final String content;
+
+  public static TermResponse of(Term term) {
+    return new TermResponse(term.getId(), term.getTitle(), term.getContent());
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/auth/service/AuthService.java
+++ b/src/main/java/org/mju_likelion/festival/auth/service/AuthService.java
@@ -15,6 +15,7 @@ import org.mju_likelion.festival.auth.dto.request.AdminLoginRequest;
 import org.mju_likelion.festival.auth.dto.request.UserLoginRequest;
 import org.mju_likelion.festival.auth.dto.response.KeyResponse;
 import org.mju_likelion.festival.auth.dto.response.LoginResponse;
+import org.mju_likelion.festival.auth.dto.response.TermResponse;
 import org.mju_likelion.festival.auth.util.jwt.JwtUtil;
 import org.mju_likelion.festival.auth.util.key.manager.RsaKeyManager;
 import org.mju_likelion.festival.auth.util.key.manager.RsaKeyManagerContext;
@@ -81,6 +82,13 @@ public class AuthService {
 
     String accessToken = jwtUtil.create(admin.getId().toString());
     return new LoginResponse(accessToken);
+  }
+
+  @Transactional(readOnly = true)
+  public List<TermResponse> getTerms() {
+    return termJpaRepository.findTermsByOrderByOrderAsc().stream()
+        .map(TermResponse::of)
+        .collect(Collectors.toList());
   }
 
   private Admin getExistingAdmin(String loginId, String password) {

--- a/src/main/java/org/mju_likelion/festival/term/domain/Term.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/Term.java
@@ -19,6 +19,9 @@ public class Term extends BaseEntity {
   @Column(nullable = false, length = TERM_CONTENT_LENGTH)
   private String content;
 
+  @Column(nullable = false)
+  private Short order;
+
   @Override
   public String toString() {
     return "Term{" +

--- a/src/main/java/org/mju_likelion/festival/term/domain/repository/TermJpaRepository.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/repository/TermJpaRepository.java
@@ -1,5 +1,6 @@
 package org.mju_likelion.festival.term.domain.repository;
 
+import java.util.List;
 import java.util.UUID;
 import org.mju_likelion.festival.term.domain.Term;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TermJpaRepository extends JpaRepository<Term, UUID> {
 
+  /**
+   * Term 의 Order 를 기준으로 오름차순으로 정렬하여 모든 Term 조회.
+   *
+   * @return Term 의 Order 를 기준으로 오름차순으로 정렬된 모든 Term
+   */
+  List<Term> findTermsByOrderByOrderAsc();
 }


### PR DESCRIPTION
## Description
동의 항목 조회 API 개발
동의 항목에 순서 컬럼 추가
## Changes
### Order 컬럼 추가
- [x] Term
### Order 순 정렬 후 반환 함수 추가
- [x] TermJpaRepository

### API
| URL                     | method | Usage                   | Authorization Needed |
| ------------------ | ---------| -------------------- | ------------------------ |
|          /auth/terms                  |     GET          |      동의 항목 조회                         |          X                          |

## Additional context
Closes #29 