### PR TITLE
Feature/#31 부스 전체/단건 조회 API 개발

### DIFF
--- a/src/main/java/org/mju_likelion/festival/auth/service/AuthService.java
+++ b/src/main/java/org/mju_likelion/festival/auth/service/AuthService.java
@@ -86,7 +86,7 @@ public class AuthService {
 
   @Transactional(readOnly = true)
   public List<TermResponse> getTerms() {
-    return termJpaRepository.findTermsByOrderByOrderAsc().stream()
+    return termJpaRepository.findTermsByOrderBySequenceAsc().stream()
         .map(TermResponse::of)
         .collect(Collectors.toList());
   }

--- a/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
+++ b/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
@@ -1,0 +1,34 @@
+package org.mju_likelion.festival.booth.controller;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.booth.dto.response.BoothDetailResponse;
+import org.mju_likelion.festival.booth.dto.response.SimpleBoothResponse;
+import org.mju_likelion.festival.booth.service.BoothQueryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/booths")
+public class BoothController {
+
+  private final BoothQueryService boothQueryService;
+
+  @GetMapping
+  public ResponseEntity<List<SimpleBoothResponse>> getBooths(
+      @RequestParam final int page,
+      @RequestParam final int size) {
+    return ResponseEntity.ok(boothQueryService.getBooths(page, size));
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<BoothDetailResponse> getBooth(@PathVariable final UUID id) {
+    return ResponseEntity.ok(boothQueryService.getBooth(id));
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
@@ -1,8 +1,10 @@
 package org.mju_likelion.festival.booth.domain;
 
 import static org.mju_likelion.festival.common.domain.constant.ColumnLengths.BOOTH_DESCRIPTION_LENGTH;
+import static org.mju_likelion.festival.common.domain.constant.ColumnLengths.BOOTH_LOCATION_LENGTH;
 import static org.mju_likelion.festival.common.domain.constant.ColumnLengths.BOOTH_NAME_LENGTH;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -16,6 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.mju_likelion.festival.admin.domain.Admin;
 import org.mju_likelion.festival.common.domain.BaseEntity;
+import org.mju_likelion.festival.image.domain.Image;
 
 @Getter
 @Builder
@@ -34,9 +37,19 @@ public class Booth extends BaseEntity {
   @Column(nullable = false, length = BOOTH_DESCRIPTION_LENGTH)
   private String description;
 
-  @OneToMany(mappedBy = "booth", fetch = FetchType.LAZY)
+  @Column(nullable = false, length = BOOTH_LOCATION_LENGTH)
+  private String location;
+
+  @Column(nullable = false)
+  private Short sequence;
+
+  @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  @JoinColumn(name = "thumbnail_id")
+  private Image thumbnail;
+
+  @OneToMany(mappedBy = "booth", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   private List<BoothUser> boothUsers;
 
-  @OneToMany(mappedBy = "booth", fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "booth", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   private List<BoothImage> boothImages;
 }

--- a/src/main/java/org/mju_likelion/festival/booth/domain/BoothDetail.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/BoothDetail.java
@@ -1,0 +1,29 @@
+package org.mju_likelion.festival.booth.domain;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class BoothDetail extends SimpleBooth {
+
+  private final String location;
+  private final List<String> imageUrls;
+  private final LocalDateTime createdAt;
+
+  public BoothDetail(
+      final UUID id,
+      final String name,
+      final String description,
+      final String location,
+      final String thumbnailUrl,
+      final List<String> imageUrls,
+      final LocalDateTime createdAt) {
+    
+    super(id, name, description, thumbnailUrl);
+    this.location = location;
+    this.imageUrls = imageUrls;
+    this.createdAt = createdAt;
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/booth/domain/SimpleBooth.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/SimpleBooth.java
@@ -1,0 +1,15 @@
+package org.mju_likelion.festival.booth.domain;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SimpleBooth {
+
+  protected final UUID id;
+  protected final String name;
+  protected final String description;
+  protected final String thumbnailUrl;
+}

--- a/src/main/java/org/mju_likelion/festival/booth/domain/repository/BoothQueryRepository.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/repository/BoothQueryRepository.java
@@ -1,0 +1,90 @@
+package org.mju_likelion.festival.booth.domain.repository;
+
+import static org.mju_likelion.festival.common.util.uuid.UUIDUtil.hexToUUID;
+import static org.mju_likelion.festival.common.util.uuid.UUIDUtil.uuidToHex;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.mju_likelion.festival.booth.domain.BoothDetail;
+import org.mju_likelion.festival.booth.domain.SimpleBooth;
+import org.springframework.dao.support.DataAccessUtils;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+@RequiredArgsConstructor
+public class BoothQueryRepository {
+
+  private final RowMapper<SimpleBooth> simpleBoothRowMapper = simpleBoothRowMapper();
+  private final RowMapper<BoothDetail> boothDetailRowMapper = boothDetailRowMapper();
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  private RowMapper<SimpleBooth> simpleBoothRowMapper() {
+    return (rs, rowNum) -> {
+      String hexId = rs.getString("boothId");
+      UUID uuid = hexToUUID(hexId);
+      return new SimpleBooth(
+          uuid,
+          rs.getString("boothName"),
+          rs.getString("boothDescription"),
+          rs.getString("thumbnailUrl")
+      );
+    };
+  }
+
+  private RowMapper<BoothDetail> boothDetailRowMapper() {
+    return (rs, rowNum) -> {
+      String hexId = rs.getString("boothId");
+      UUID uuid = hexToUUID(hexId);
+      return new BoothDetail(
+          uuid,
+          rs.getString("boothName"),
+          rs.getString("boothDescription"),
+          rs.getString("boothLocation"),
+          rs.getString("thumbnailUrl"),
+          List.of(rs.getString("imageUrl")),
+          rs.getTimestamp("createdAt").toLocalDateTime()
+      );
+    };
+  }
+
+  public List<SimpleBooth> findOrderedSimpleBoothsWithPagination(final int page, final int size) {
+    String sql =
+        "SELECT HEX(b.id) AS boothId, b.name AS boothName, b.description AS boothDescription, "
+            + "i.url AS thumbnailUrl "
+            + "FROM booth b "
+            + "LEFT JOIN image i ON b.thumbnail_id = i.id "
+            + "ORDER BY b.sequence ASC "
+            + "LIMIT :limit OFFSET :offset";
+
+    MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("limit", size)
+        .addValue("offset", page * size);
+
+    return jdbcTemplate.query(sql, params, simpleBoothRowMapper);
+  }
+
+  public Optional<BoothDetail> findBoothById(final UUID id) {
+    String sql =
+        "SELECT HEX(b.id) AS boothId, b.name AS boothName, b.description AS boothDescription, "
+            + "b.location AS boothLocation, i.url AS imageUrl, ti.url AS thumbnailUrl, "
+            + "b.created_at AS createdAt "
+            + "FROM booth b "
+            + "LEFT JOIN booth_image bi ON b.id = bi.booth_id "
+            + "LEFT JOIN image i ON bi.image_id = i.id "
+            + "LEFT JOIN image ti ON b.thumbnail_id = ti.id "
+            + "WHERE b.id = UNHEX(:id)";
+
+    MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("id", uuidToHex(id));
+
+    return Optional
+        .ofNullable(
+            DataAccessUtils.singleResult(jdbcTemplate.query(sql, params, boothDetailRowMapper)));
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/booth/dto/response/BoothDetailResponse.java
+++ b/src/main/java/org/mju_likelion/festival/booth/dto/response/BoothDetailResponse.java
@@ -1,0 +1,36 @@
+package org.mju_likelion.festival.booth.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import org.mju_likelion.festival.booth.domain.BoothDetail;
+
+@Getter
+public class BoothDetailResponse extends SimpleBoothResponse {
+
+  private final String location;
+  private final List<String> imageUrl;
+  private final LocalDateTime createdAt;
+
+  public BoothDetailResponse(
+      final UUID id,
+      final String name,
+      final String description,
+      final String location,
+      final String thumbnailUrl,
+      final List<String> imageUrl,
+      final LocalDateTime createdAt) {
+
+    super(id, name, description, thumbnailUrl);
+    this.location = location;
+    this.imageUrl = imageUrl;
+    this.createdAt = createdAt;
+  }
+
+  public static BoothDetailResponse from(final BoothDetail boothDetail) {
+    return new BoothDetailResponse(boothDetail.getId(), boothDetail.getName(),
+        boothDetail.getDescription(), boothDetail.getLocation(), boothDetail.getThumbnailUrl(),
+        boothDetail.getImageUrls(), boothDetail.getCreatedAt());
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/booth/dto/response/SimpleBoothResponse.java
+++ b/src/main/java/org/mju_likelion/festival/booth/dto/response/SimpleBoothResponse.java
@@ -1,0 +1,21 @@
+package org.mju_likelion.festival.booth.dto.response;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.mju_likelion.festival.booth.domain.SimpleBooth;
+
+@Getter
+@AllArgsConstructor
+public class SimpleBoothResponse {
+
+  private final UUID id;
+  private final String name;
+  private final String description;
+  private final String thumbnailUrl;
+
+  public static SimpleBoothResponse from(final SimpleBooth simpleBooth) {
+    return new SimpleBoothResponse(simpleBooth.getId(), simpleBooth.getName(),
+        simpleBooth.getDescription(), simpleBooth.getThumbnailUrl());
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
@@ -1,0 +1,35 @@
+package org.mju_likelion.festival.booth.service;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.BOOTH_NOT_FOUND;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.booth.domain.repository.BoothQueryRepository;
+import org.mju_likelion.festival.booth.dto.response.BoothDetailResponse;
+import org.mju_likelion.festival.booth.dto.response.SimpleBoothResponse;
+import org.mju_likelion.festival.common.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+@Transactional(readOnly = true)
+public class BoothQueryService {
+
+  private final BoothQueryRepository boothQueryRepository;
+
+  public List<SimpleBoothResponse> getBooths(final int page, final int size) {
+    return boothQueryRepository.findOrderedSimpleBoothsWithPagination(page, size)
+        .stream().map(SimpleBoothResponse::from).toList();
+  }
+
+  public BoothDetailResponse getBooth(final UUID id) {
+    return BoothDetailResponse.from(
+        boothQueryRepository.findBoothById(id).orElseThrow(
+            () -> new NotFoundException(BOOTH_NOT_FOUND)
+        )
+    );
+  }
+}
+

--- a/src/main/java/org/mju_likelion/festival/common/domain/BaseEntity.java
+++ b/src/main/java/org/mju_likelion/festival/common/domain/BaseEntity.java
@@ -20,7 +20,7 @@ public abstract class BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "uuid2")
-  @Column(name = "id", updatable = false, unique = true, nullable = false)
+  @Column(name = "id", updatable = false, unique = true, nullable = false, columnDefinition = "BINARY(16)")
   protected UUID id;
 
   @CreatedDate

--- a/src/main/java/org/mju_likelion/festival/common/domain/constant/ColumnLengths.java
+++ b/src/main/java/org/mju_likelion/festival/common/domain/constant/ColumnLengths.java
@@ -18,6 +18,7 @@ public abstract class ColumnLengths {
 
   public static final int BOOTH_NAME_LENGTH = 100;
   public static final int BOOTH_DESCRIPTION_LENGTH = 4000;
+  public static final int BOOTH_LOCATION_LENGTH = 100;
 
   public static final int ANNOUNCEMENT_TITLE_LENGTH = 100;
   public static final int ANNOUNCEMENT_CONTENT_LENGTH = 4000;

--- a/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
@@ -21,6 +21,7 @@ public enum ErrorType {
   INVALID_CREDENTIALS(4010, "아이디나 비밀번호가 일치하지 않습니다."),
 
   NO_RESOURCE_ERROR(4040, "해당 리소스를 찾을 수 없습니다."),
+  BOOTH_NOT_FOUND(4041, "해당 부스를 찾을 수 없습니다."),
 
   METHOD_NOT_ALLOWED_ERROR(4050, "허용되지 않은 HTTP 메소드입니다."),
 
@@ -30,6 +31,7 @@ public enum ErrorType {
 
   INVALID_JWT(5000, "JWT 토큰이 유효하지 않습니다."),
   API_ERROR(5001, "API 호출 중 오류가 발생했습니다."),
+  UUID_FORMAT_ERROR(5002, "UUID 형식이 잘못되었습니다."),
 
   REDIS_ERROR(6000, "Redis 에러가 발생했습니다.");
 

--- a/src/main/java/org/mju_likelion/festival/common/util/uuid/UUIDUtil.java
+++ b/src/main/java/org/mju_likelion/festival/common/util/uuid/UUIDUtil.java
@@ -1,0 +1,27 @@
+package org.mju_likelion.festival.common.util.uuid;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.UUID_FORMAT_ERROR;
+
+import java.util.UUID;
+import org.mju_likelion.festival.common.exception.InternalServerException;
+
+public class UUIDUtil {
+
+  private static final String DASH = "-";
+
+  public static UUID hexToUUID(final String hex) {
+    if (hex.length() != 32) {
+      throw new InternalServerException(UUID_FORMAT_ERROR);
+    }
+    StringBuilder sb = new StringBuilder(hex);
+    sb.insert(8, DASH);
+    sb.insert(13, DASH);
+    sb.insert(18, DASH);
+    sb.insert(23, DASH);
+    return UUID.fromString(sb.toString());
+  }
+
+  public static String uuidToHex(final UUID uuid) {
+    return uuid.toString().replace(DASH, "");
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/image/domain/Image.java
+++ b/src/main/java/org/mju_likelion/festival/image/domain/Image.java
@@ -2,17 +2,18 @@ package org.mju_likelion.festival.image.domain;
 
 import static org.mju_likelion.festival.common.domain.constant.ColumnLengths.IMAGE_URL_LENGTH;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.mju_likelion.festival.announcement.domain.AnnouncementImage;
+import org.mju_likelion.festival.booth.domain.Booth;
 import org.mju_likelion.festival.booth.domain.BoothImage;
 import org.mju_likelion.festival.common.domain.BaseEntity;
 import org.mju_likelion.festival.lost_item.domain.LostItemImage;
@@ -27,12 +28,15 @@ public class Image extends BaseEntity {
   @Column(nullable = false, length = IMAGE_URL_LENGTH, unique = true)
   private String url;
 
-  @OneToMany(mappedBy = "image", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  @OneToOne(mappedBy = "thumbnail", fetch = FetchType.LAZY)
+  private Booth booth;
+
+  @OneToMany(mappedBy = "image", fetch = FetchType.LAZY)
   private List<LostItemImage> lostItemImages;
 
-  @OneToMany(mappedBy = "image", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "image", fetch = FetchType.LAZY)
   private List<BoothImage> boothImages;
 
-  @OneToMany(mappedBy = "image", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "image", fetch = FetchType.LAZY)
   private List<AnnouncementImage> announcementImages;
 }

--- a/src/main/java/org/mju_likelion/festival/term/domain/Term.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/Term.java
@@ -20,7 +20,7 @@ public class Term extends BaseEntity {
   private String content;
 
   @Column(nullable = false)
-  private Short order;
+  private Short sequence;
 
   @Override
   public String toString() {

--- a/src/main/java/org/mju_likelion/festival/term/domain/repository/TermJpaRepository.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/repository/TermJpaRepository.java
@@ -14,5 +14,5 @@ public interface TermJpaRepository extends JpaRepository<Term, UUID> {
    *
    * @return Term 의 Order 를 기준으로 오름차순으로 정렬된 모든 Term
    */
-  List<Term> findTermsByOrderByOrderAsc();
+  List<Term> findTermsByOrderBySequenceAsc();
 }


### PR DESCRIPTION
## Description
부스 전체/단건 조회 API 개발
부스 sequence, location, thumbnail_id 컬럼 추가

전체 조회 시 생성 시간 순 조회

추후 전체 조회 시 Filtering 가능성
## Changes
### order 컬럼 네이밍 변경 -> sequence
- [x] Term
### 부스 sequence, location, thumbnail_id 컬럼 추가
- [x] Booth
- [x] Image
### BaseEntity 컬럼 정의 변경 (UUID 이슈)
- [x] BaseEntity
### UUIDUtil
- [x] UUIDUtil
### BoothQueryRepository 구현
- [x] BoothQueryRepository 

### API
| URL                     | method | Usage                   | Authorization Needed |
| ------------------ | ---------| -------------------- | ------------------------ |
|             /booths?page={page}&size={size}               |         GET      |             부스 전체 조회                  |            X                        |
|             /booths/{id}              |         GET      |             부스 단건 조회                  |            X                        |
## Additional context
BoothQueryRepository 에서 NamedParameterJdbcTemplate 사용
- 원하는 데이터만 가져오기 위함
- 효율적인 쿼리 작성을 위함


Closes #31 