### PR TITLE
Feature/#36 AUTH 인터셉터 추가

### DIFF
--- a/src/main/java/org/mju_likelion/festival/auth/service/AuthService.java
+++ b/src/main/java/org/mju_likelion/festival/auth/service/AuthService.java
@@ -16,7 +16,9 @@ import org.mju_likelion.festival.auth.dto.request.UserLoginRequest;
 import org.mju_likelion.festival.auth.dto.response.KeyResponse;
 import org.mju_likelion.festival.auth.dto.response.LoginResponse;
 import org.mju_likelion.festival.auth.dto.response.TermResponse;
+import org.mju_likelion.festival.auth.util.jwt.AuthenticationRole;
 import org.mju_likelion.festival.auth.util.jwt.JwtUtil;
+import org.mju_likelion.festival.auth.util.jwt.Payload;
 import org.mju_likelion.festival.auth.util.key.manager.RsaKeyManager;
 import org.mju_likelion.festival.auth.util.key.manager.RsaKeyManagerContext;
 import org.mju_likelion.festival.common.exception.BadRequestException;
@@ -65,7 +67,7 @@ public class AuthService {
 
     UUID userId = saveOrGetUserId(studentId, userLoginRequest.getTerms());
 
-    String accessToken = jwtUtil.create(userId.toString());
+    String accessToken = jwtUtil.create(new Payload(userId, AuthenticationRole.USER));
     return new LoginResponse(accessToken);
   }
 
@@ -80,7 +82,8 @@ public class AuthService {
 
     Admin admin = getExistingAdmin(loginId, password);
 
-    String accessToken = jwtUtil.create(admin.getId().toString());
+    String accessToken = jwtUtil.create(
+        new Payload(admin.getId(), AuthenticationRole.from(admin.getRole())));
     return new LoginResponse(accessToken);
   }
 

--- a/src/main/java/org/mju_likelion/festival/auth/util/jwt/AuthenticationRole.java
+++ b/src/main/java/org/mju_likelion/festival/auth/util/jwt/AuthenticationRole.java
@@ -1,0 +1,28 @@
+package org.mju_likelion.festival.auth.util.jwt;
+
+import org.mju_likelion.festival.admin.domain.AdminRole;
+
+/**
+ * 인증에 사용되는 역할을 나타내는 Enum.
+ */
+public enum AuthenticationRole {
+  STUDENT_COUNCIL, BOOTH_MANAGER, USER;
+
+  /**
+   * AdminRole 로부터 AuthenticationRole 을 생성한다.
+   *
+   * @param adminRole AdminRole
+   * @return AuthenticationRole
+   */
+  public static AuthenticationRole from(AdminRole adminRole) {
+    return switch (adminRole) {
+      case STUDENT_COUNCIL -> STUDENT_COUNCIL;
+      case BOOTH_MANAGER -> BOOTH_MANAGER;
+    };
+  }
+
+  @Override
+  public String toString() {
+    return name().toLowerCase();
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/auth/util/jwt/Payload.java
+++ b/src/main/java/org/mju_likelion/festival/auth/util/jwt/Payload.java
@@ -1,0 +1,21 @@
+package org.mju_likelion.festival.auth.util.jwt;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * JWT 토큰의 payload 부분을 나타내는 클래스.
+ */
+@Getter
+@AllArgsConstructor
+public class Payload {
+
+  private UUID id;
+  private AuthenticationRole role;
+
+  @Override
+  public String toString() {
+    return id.toString() + ":" + role.toString();
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/authentication/AuthenticationArgumentResolver.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/AuthenticationArgumentResolver.java
@@ -1,0 +1,30 @@
+package org.mju_likelion.festival.common.authentication;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
+
+  private final AuthenticationContext authenticationContext;
+
+  @Override
+  public boolean supportsParameter(final MethodParameter parameter) {
+    return parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+  }
+
+  @Override
+  public UUID resolveArgument(final MethodParameter parameter,
+      final ModelAndViewContainer mavContainer,
+      final NativeWebRequest webRequest,
+      final WebDataBinderFactory binderFactory) {
+    return authenticationContext.getPrincipal();
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/authentication/AuthenticationContext.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/AuthenticationContext.java
@@ -1,0 +1,30 @@
+package org.mju_likelion.festival.common.authentication;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.ALREADY_AUTHENTICATED_ERROR;
+import static org.mju_likelion.festival.common.exception.type.ErrorType.NOT_AUTHENTICATED_ERROR;
+
+import java.util.UUID;
+import org.mju_likelion.festival.common.exception.UnauthorizedException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Component
+@RequestScope
+public class AuthenticationContext {
+
+  private UUID principal;
+
+  public UUID getPrincipal() {
+    if (principal == null) {
+      throw new UnauthorizedException(NOT_AUTHENTICATED_ERROR);
+    }
+    return principal;
+  }
+
+  public void setPrincipal(final UUID principal) {
+    if (this.principal != null) {
+      throw new UnauthorizedException(ALREADY_AUTHENTICATED_ERROR);
+    }
+    this.principal = principal;
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/authentication/AuthenticationPrincipal.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/AuthenticationPrincipal.java
@@ -1,0 +1,12 @@
+package org.mju_likelion.festival.common.authentication;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticationPrincipal {
+
+}

--- a/src/main/java/org/mju_likelion/festival/common/authentication/AuthorizationExtractor.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/AuthorizationExtractor.java
@@ -1,0 +1,29 @@
+package org.mju_likelion.festival.common.authentication;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.logging.log4j.util.Strings;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuthorizationExtractor {
+
+  private static final String AUTHORIZATION_HEADER_TYPE = "Authorization";
+  private static final String TOKEN_TYPE = "Bearer";
+
+  public static Optional<String> extract(final HttpServletRequest request) {
+    String header = request.getHeader(AUTHORIZATION_HEADER_TYPE);
+    if (Strings.isEmpty(header)) {
+      return Optional.empty();
+    }
+    return checkMatch(header.split(" "));
+  }
+
+  private static Optional<String> checkMatch(final String[] parts) {
+    if (parts.length == 2 && parts[0].equals(TOKEN_TYPE)) {
+      return Optional.ofNullable(parts[1]);
+    }
+    return Optional.empty();
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/AbstractAuthenticationInterceptor.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/AbstractAuthenticationInterceptor.java
@@ -1,0 +1,46 @@
+package org.mju_likelion.festival.common.authentication.interceptor;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.JWT_NOT_FOUND_ERROR;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.mju_likelion.festival.auth.util.jwt.JwtUtil;
+import org.mju_likelion.festival.auth.util.jwt.Payload;
+import org.mju_likelion.festival.common.authentication.AuthenticationContext;
+import org.mju_likelion.festival.common.authentication.AuthorizationExtractor;
+import org.mju_likelion.festival.common.exception.ForbiddenException;
+import org.mju_likelion.festival.common.exception.UnauthorizedException;
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public abstract class AbstractAuthenticationInterceptor implements HandlerInterceptor {
+
+  private final AuthenticationContext authenticationContext;
+  private final JwtUtil userJwtUtil;
+
+  protected AbstractAuthenticationInterceptor(AuthenticationContext authenticationContext,
+      JwtUtil userJwtUtil) {
+    this.authenticationContext = authenticationContext;
+    this.userJwtUtil = userJwtUtil;
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+      Object handler) {
+    String accessToken = AuthorizationExtractor.extract(request)
+        .orElseThrow(() -> new UnauthorizedException(JWT_NOT_FOUND_ERROR));
+    Payload payload = userJwtUtil.getPayload(accessToken);
+
+    if (!isAuthorized(payload)) {
+      throw new ForbiddenException(getErrorType());
+    }
+
+    authenticationContext.setPrincipal(payload.getId());
+    return true;
+  }
+
+  protected abstract boolean isAuthorized(Payload payload);
+
+  protected abstract ErrorType getErrorType();
+}
+

--- a/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/AdminAuthenticationInterceptor.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/AdminAuthenticationInterceptor.java
@@ -1,0 +1,31 @@
+package org.mju_likelion.festival.common.authentication.interceptor;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.ADMIN_ONLY_ERROR;
+
+import java.util.Objects;
+import org.mju_likelion.festival.auth.util.jwt.AuthenticationRole;
+import org.mju_likelion.festival.auth.util.jwt.JwtUtil;
+import org.mju_likelion.festival.auth.util.jwt.Payload;
+import org.mju_likelion.festival.common.authentication.AuthenticationContext;
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AdminAuthenticationInterceptor extends AbstractAuthenticationInterceptor {
+
+  public AdminAuthenticationInterceptor(AuthenticationContext authenticationContext,
+      JwtUtil userJwtUtil) {
+    super(authenticationContext, userJwtUtil);
+  }
+
+  @Override
+  protected boolean isAuthorized(Payload payload) {
+    return !Objects.equals(payload.getRole(), AuthenticationRole.USER);
+  }
+
+  @Override
+  protected ErrorType getErrorType() {
+    return ADMIN_ONLY_ERROR;
+  }
+}
+

--- a/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/BoothAdminAuthenticationInterceptor.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/BoothAdminAuthenticationInterceptor.java
@@ -1,0 +1,30 @@
+package org.mju_likelion.festival.common.authentication.interceptor;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.BOOTH_MANAGER_ONLY_ERROR;
+
+import java.util.Objects;
+import org.mju_likelion.festival.auth.util.jwt.AuthenticationRole;
+import org.mju_likelion.festival.auth.util.jwt.JwtUtil;
+import org.mju_likelion.festival.auth.util.jwt.Payload;
+import org.mju_likelion.festival.common.authentication.AuthenticationContext;
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BoothAdminAuthenticationInterceptor extends AbstractAuthenticationInterceptor {
+
+  public BoothAdminAuthenticationInterceptor(AuthenticationContext authenticationContext,
+      JwtUtil userJwtUtil) {
+    super(authenticationContext, userJwtUtil);
+  }
+
+  @Override
+  protected boolean isAuthorized(Payload payload) {
+    return Objects.equals(payload.getRole(), AuthenticationRole.BOOTH_MANAGER);
+  }
+
+  @Override
+  protected ErrorType getErrorType() {
+    return BOOTH_MANAGER_ONLY_ERROR;
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/StudentCouncilAuthenticationInterceptor.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/StudentCouncilAuthenticationInterceptor.java
@@ -1,0 +1,30 @@
+package org.mju_likelion.festival.common.authentication.interceptor;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.STUDENT_COUNCIL_ONLY_ERROR;
+
+import java.util.Objects;
+import org.mju_likelion.festival.auth.util.jwt.AuthenticationRole;
+import org.mju_likelion.festival.auth.util.jwt.JwtUtil;
+import org.mju_likelion.festival.auth.util.jwt.Payload;
+import org.mju_likelion.festival.common.authentication.AuthenticationContext;
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StudentCouncilAuthenticationInterceptor extends AbstractAuthenticationInterceptor {
+
+  public StudentCouncilAuthenticationInterceptor(AuthenticationContext authenticationContext,
+      JwtUtil userJwtUtil) {
+    super(authenticationContext, userJwtUtil);
+  }
+
+  @Override
+  protected boolean isAuthorized(Payload payload) {
+    return Objects.equals(payload.getRole(), AuthenticationRole.STUDENT_COUNCIL);
+  }
+
+  @Override
+  protected ErrorType getErrorType() {
+    return STUDENT_COUNCIL_ONLY_ERROR;
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/UserAuthenticationInterceptor.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/UserAuthenticationInterceptor.java
@@ -1,0 +1,31 @@
+package org.mju_likelion.festival.common.authentication.interceptor;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.USER_ONLY_ERROR;
+
+import java.util.Objects;
+import org.mju_likelion.festival.auth.util.jwt.AuthenticationRole;
+import org.mju_likelion.festival.auth.util.jwt.JwtUtil;
+import org.mju_likelion.festival.auth.util.jwt.Payload;
+import org.mju_likelion.festival.common.authentication.AuthenticationContext;
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserAuthenticationInterceptor extends AbstractAuthenticationInterceptor {
+
+  public UserAuthenticationInterceptor(AuthenticationContext authenticationContext,
+      JwtUtil userJwtUtil) {
+    super(authenticationContext, userJwtUtil);
+  }
+
+  @Override
+  protected boolean isAuthorized(Payload payload) {
+    return Objects.equals(payload.getRole(), AuthenticationRole.USER);
+  }
+
+  @Override
+  protected ErrorType getErrorType() {
+    return USER_ONLY_ERROR;
+  }
+}
+

--- a/src/main/java/org/mju_likelion/festival/common/config/AuthenticationConfig.java
+++ b/src/main/java/org/mju_likelion/festival/common/config/AuthenticationConfig.java
@@ -1,0 +1,77 @@
+package org.mju_likelion.festival.common.config;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.mju_likelion.festival.common.authentication.AuthenticationArgumentResolver;
+import org.mju_likelion.festival.common.authentication.interceptor.AdminAuthenticationInterceptor;
+import org.mju_likelion.festival.common.authentication.interceptor.BoothAdminAuthenticationInterceptor;
+import org.mju_likelion.festival.common.authentication.interceptor.StudentCouncilAuthenticationInterceptor;
+import org.mju_likelion.festival.common.authentication.interceptor.UserAuthenticationInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class AuthenticationConfig implements WebMvcConfigurer {
+
+  private final UserAuthenticationInterceptor userAuthenticationInterceptor;
+  private final StudentCouncilAuthenticationInterceptor studentCouncilAuthenticationInterceptor;
+  private final BoothAdminAuthenticationInterceptor boothAdminAuthenticationInterceptor;
+  private final AdminAuthenticationInterceptor adminAuthenticationInterceptor;
+  private final AuthenticationArgumentResolver authenticationArgumentResolver;
+
+  @Override
+  public void addInterceptors(final InterceptorRegistry registry) {
+    // addUserAuthenticationInterceptor(registry);
+    // addStudentCouncilAuthenticationInterceptor(registry);
+    // addBoothAdminAuthenticationInterceptor(registry);
+    // addAdminAuthenticationInterceptor(registry);
+  }
+
+  /**
+   * 부스 관리자 권한 인증 인터셉터를 추가한다. 부스 관리자만 접근 가능
+   *
+   * @param registry 인터셉터 레지스트리
+   */
+  private void addBoothAdminAuthenticationInterceptor(final InterceptorRegistry registry) {
+    registry.addInterceptor(boothAdminAuthenticationInterceptor)
+        .addPathPatterns();
+  }
+
+  /**
+   * 학생회 권한 인증 인터셉터를 추가한다. 학생회만 접근 가능
+   *
+   * @param registry 인터셉터 레지스트리
+   */
+  private void addStudentCouncilAuthenticationInterceptor(final InterceptorRegistry registry) {
+    registry.addInterceptor(studentCouncilAuthenticationInterceptor)
+        .addPathPatterns();
+  }
+
+  /**
+   * 관리자 권한 인증 인터셉터를 추가한다. 관리자만 접근 가능
+   *
+   * @param registry 인터셉터 레지스트리
+   */
+  private void addAdminAuthenticationInterceptor(final InterceptorRegistry registry) {
+    registry.addInterceptor(adminAuthenticationInterceptor)
+        .addPathPatterns();
+  }
+
+  /**
+   * 사용자 권한 인증 인터셉터를 추가한다. 로그인한 사용자만 접근 가능 관리자는 접근 불가
+   *
+   * @param registry 인터셉터 레지스트리
+   */
+  private void addUserAuthenticationInterceptor(final InterceptorRegistry registry) {
+    registry.addInterceptor(userAuthenticationInterceptor)
+        .addPathPatterns();
+  }
+
+  @Override
+  public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(authenticationArgumentResolver);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
@@ -19,6 +19,15 @@ public enum ErrorType {
   MISSING_TERM(4003, "동의 항목이 누락되었습니다."),
 
   INVALID_CREDENTIALS(4010, "아이디나 비밀번호가 일치하지 않습니다."),
+  NOT_AUTHENTICATED_ERROR(4011, "인증되지 않았습니다."),
+  ALREADY_AUTHENTICATED_ERROR(4012, "이미 인증되었습니다."),
+  JWT_NOT_FOUND_ERROR(4013, "JWT 토큰이 없습니다."),
+  INVALID_JWT_ERROR(4014, "JWT 토큰이 유효하지 않습니다."),
+
+  USER_ONLY_ERROR(4030, "사용자만 접근할 수 있습니다."),
+  ADMIN_ONLY_ERROR(4031, "관리자만 접근할 수 있습니다."),
+  STUDENT_COUNCIL_ONLY_ERROR(4032, "학생회만 접근할 수 있습니다."),
+  BOOTH_MANAGER_ONLY_ERROR(4033, "부스 관리자만 접근할 수 있습니다."),
 
   NO_RESOURCE_ERROR(4040, "해당 리소스를 찾을 수 없습니다."),
   BOOTH_NOT_FOUND(4041, "해당 부스를 찾을 수 없습니다."),
@@ -29,7 +38,6 @@ public enum ErrorType {
 
   HTTP_MEDIA_TYPE_NOT_SUPPORTED_ERROR(4150, "지원하지 않는 미디어 타입입니다."),
 
-  INVALID_JWT(5000, "JWT 토큰이 유효하지 않습니다."),
   API_ERROR(5001, "API 호출 중 오류가 발생했습니다."),
   UUID_FORMAT_ERROR(5002, "UUID 형식이 잘못되었습니다."),
 


### PR DESCRIPTION
## Description
AUTH 인터셉터 추가
## Changes
### JwtUtil 리팩터링
- [x] Payload
- [x] AuthenticationRole
- [x] JwtUtil
- [x] AuthService

### 인증 정보 Context
- [x] AuthenticationContext

### 인증 정보 어노테이션
- [x] AuthenticationPrincipal

### 인증 정보 어노테이션 Resolver
- [x] AuthenticationArgumentResolver

### 인증 정보 Extractor
- [x] AuthorizationExtractor

### 추상 인증 인터셉터 
- [x] AbstractAuthenticationInterceptor

### 필요 인터셉터 구현
- [x] UserAuthenticationInterceptor
- [x] StudentCouncilAuthenticationInterceptor
- [x] BoothAdminAuthenticationInterceptor
- [x] AdminAuthenticationInterceptor

### 인증 Config 작성
- [x] AuthenticationConfig

## Additional context
Closes #36 