### PR TITLE
Feature/#52 부스 QR 방문 처리 API 개발

### DIFF
--- a/src/main/java/org/mju_likelion/festival/admin/domain/repository/AdminJpaRepository.java
+++ b/src/main/java/org/mju_likelion/festival/admin/domain/repository/AdminJpaRepository.java
@@ -17,4 +17,9 @@ public interface AdminJpaRepository extends JpaRepository<Admin, UUID> {
    * @return Admin
    */
   Optional<Admin> findByLoginIdAndPassword(String loginId, String password);
+
+  /**
+   * 부스 ID 로 Admin 조회.
+   */
+  Optional<Admin> findByBoothId(UUID boothId);
 }

--- a/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
+++ b/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
@@ -3,14 +3,17 @@ package org.mju_likelion.festival.booth.controller;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.booth.domain.BoothQrStrategy;
 import org.mju_likelion.festival.booth.dto.response.BoothDetailResponse;
 import org.mju_likelion.festival.booth.dto.response.BoothQrResponse;
 import org.mju_likelion.festival.booth.dto.response.SimpleBoothResponse;
 import org.mju_likelion.festival.booth.service.BoothQueryService;
+import org.mju_likelion.festival.booth.service.BoothService;
 import org.mju_likelion.festival.common.authentication.AuthenticationPrincipal;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class BoothController {
 
   private final BoothQueryService boothQueryService;
+  private final BoothService boothService;
 
   @GetMapping
   public ResponseEntity<List<SimpleBoothResponse>> getBooths(
@@ -38,5 +42,13 @@ public class BoothController {
   public ResponseEntity<BoothQrResponse> getBoothQr(@PathVariable final UUID id,
       @AuthenticationPrincipal final UUID boothAdminId) {
     return ResponseEntity.ok(boothQueryService.getBoothQr(id, boothAdminId));
+  }
+
+  @PostMapping("/{qrId}/visit")
+  public ResponseEntity<Void> visitBooth(@PathVariable final String qrId,
+      @RequestParam final BoothQrStrategy strategy,
+      @AuthenticationPrincipal final UUID userId) {
+    boothService.visitBooth(qrId, strategy, userId);
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
@@ -48,8 +48,5 @@ public class Booth extends BaseEntity {
   private Image thumbnail;
 
   @OneToMany(mappedBy = "booth", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-  private List<BoothUser> boothUsers;
-
-  @OneToMany(mappedBy = "booth", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   private List<BoothImage> boothImages;
 }

--- a/src/main/java/org/mju_likelion/festival/booth/domain/BoothUser.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/BoothUser.java
@@ -25,4 +25,15 @@ public class BoothUser extends BaseEntity {
   @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
+
+  /**
+   * 사용자와 부스가 자신의 사용자와 부스와 같은지 확인한다.
+   *
+   * @param user  사용자
+   * @param booth 부스
+   * @return 사용자와 부스가 자신의 사용자와 부스와 같은지 여부
+   */
+  public boolean isSameUserAndBooth(User user, Booth booth) {
+    return this.user.equals(user) && this.booth.equals(booth);
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/domain/BoothUsers.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/BoothUsers.java
@@ -1,0 +1,61 @@
+package org.mju_likelion.festival.booth.domain;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.ALREADY_VISITED_BOOTH;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
+import java.util.HashSet;
+import java.util.Set;
+import org.mju_likelion.festival.common.exception.ConflictException;
+import org.mju_likelion.festival.user.domain.User;
+
+@Embeddable
+public class BoothUsers {
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  private Set<BoothUser> boothUsers = new HashSet<>();
+
+  /**
+   * 사용자가 부스를 방문한다.
+   *
+   * @param user  사용자
+   * @param booth 부스
+   */
+  public void visit(User user, Booth booth) {
+
+    validateVisitBooth(user, booth);
+
+    BoothUser boothUser = BoothUser.builder()
+        .user(user)
+        .booth(booth)
+        .build();
+
+    this.boothUsers.add(boothUser);
+  }
+
+  /**
+   * 사용자가 이미 방문한 부스인지 검증한다.
+   *
+   * @param user  사용자
+   * @param booth 부스
+   */
+  private void validateVisitBooth(User user, Booth booth) {
+    if (isVisitedBooth(user, booth)) {
+      throw new ConflictException(ALREADY_VISITED_BOOTH);
+    }
+  }
+
+  /**
+   * 사용자가 부스를 방문했는지 확인한다.
+   *
+   * @param user  사용자
+   * @param booth 부스
+   * @return 사용자가 부스를 방문했는지 여부
+   */
+  private boolean isVisitedBooth(User user, Booth booth) {
+    return this.boothUsers.stream()
+        .anyMatch(boothUser -> boothUser.isSameUserAndBooth(user, booth));
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/booth/domain/repository/BoothUserJpaRepository.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/repository/BoothUserJpaRepository.java
@@ -1,11 +1,22 @@
 package org.mju_likelion.festival.booth.domain.repository;
 
+import java.util.Optional;
 import java.util.UUID;
+import org.mju_likelion.festival.booth.domain.Booth;
 import org.mju_likelion.festival.booth.domain.BoothUser;
+import org.mju_likelion.festival.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoothUserJpaRepository extends JpaRepository<BoothUser, UUID> {
 
+  /**
+   * 사용자와 부스로 부스 사용자 조회. 테스트 코드 작성을 위해 추가함.
+   *
+   * @param user  사용자
+   * @param booth 부스
+   * @return 부스 사용자
+   */
+  Optional<BoothUser> findByUserAndBooth(User user, Booth booth);
 }

--- a/src/main/java/org/mju_likelion/festival/booth/service/BoothService.java
+++ b/src/main/java/org/mju_likelion/festival/booth/service/BoothService.java
@@ -1,0 +1,50 @@
+package org.mju_likelion.festival.booth.service;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.BOOTH_NOT_FOUND_ERROR;
+import static org.mju_likelion.festival.common.exception.type.ErrorType.USER_NOT_FOUND_ERROR;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.booth.domain.Booth;
+import org.mju_likelion.festival.booth.domain.BoothQrStrategy;
+import org.mju_likelion.festival.booth.domain.repository.BoothJpaRepository;
+import org.mju_likelion.festival.booth.util.qr.BoothQrManager;
+import org.mju_likelion.festival.booth.util.qr.BoothQrManagerContext;
+import org.mju_likelion.festival.common.exception.NotFoundException;
+import org.mju_likelion.festival.user.domain.User;
+import org.mju_likelion.festival.user.domain.repository.UserJpaRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+@Transactional
+public class BoothService {
+
+  private final BoothQrManagerContext boothQrManagerContext;
+  private final BoothJpaRepository boothJpaRepository;
+  private final UserJpaRepository userJpaRepository;
+
+  public void visitBooth(final String qrId, final BoothQrStrategy boothQrStrategy,
+      final UUID userId) {
+    BoothQrManager boothQrManager = boothQrManagerContext.boothQrManager(boothQrStrategy);
+
+    UUID boothId = boothQrManager.getBoothIdFromQrId(qrId);
+
+    User user = getExistingUser(userId);
+    Booth booth = getExistingBooth(boothId);
+
+    user.visitBooth(booth);
+    userJpaRepository.save(user);
+  }
+
+  private User getExistingUser(final UUID userId) {
+    return userJpaRepository.findById(userId)
+        .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND_ERROR));
+  }
+
+  private Booth getExistingBooth(final UUID boothId) {
+    return boothJpaRepository.findById(boothId)
+        .orElseThrow(() -> new NotFoundException(BOOTH_NOT_FOUND_ERROR));
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/booth/util/qr/RedisBoothQrManager.java
+++ b/src/main/java/org/mju_likelion/festival/booth/util/qr/RedisBoothQrManager.java
@@ -20,20 +20,19 @@ import org.springframework.stereotype.Component;
 public class RedisBoothQrManager implements BoothQrManager {
 
   private final QrGenerator qrGenerator;
-  private final RedisUtil<UUID, UUID> redisUtil;
+  private final RedisUtil<UUID, String> redisUtil;
 
   @Override
   public String generateBoothQr(final UUID boothId) {
     UUID qrId = UUID.randomUUID();
-    redisUtil.insert(qrId, boothId, qrExpireTime);
+    redisUtil.insert(qrId, boothId.toString(), qrExpireTime);
     return qrGenerator.generateQrCode("/booths/", qrId.toString(), getQuery());
   }
 
   @Override
   public UUID getBoothIdFromQrId(final String qrId) {
     UUID redisKey = UUID.fromString(qrId);
-
-    UUID boothId = getBoothId(redisKey);
+    UUID boothId = UUID.fromString(getBoothId(redisKey));
     deleteBoothId(redisKey);
 
     return boothId;
@@ -44,7 +43,7 @@ public class RedisBoothQrManager implements BoothQrManager {
     return BoothQrStrategy.REDIS;
   }
 
-  private UUID getBoothId(UUID qrId) {
+  private String getBoothId(UUID qrId) {
     return redisUtil.select(qrId)
         .orElseThrow(() -> new NotFoundException(BOOTH_QR_NOT_FOUND_ERROR));
   }

--- a/src/main/java/org/mju_likelion/festival/booth/util/qr/TokenBoothQrManager.java
+++ b/src/main/java/org/mju_likelion/festival/booth/util/qr/TokenBoothQrManager.java
@@ -1,5 +1,6 @@
 package org.mju_likelion.festival.booth.util.qr;
 
+import java.util.Base64;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.mju_likelion.festival.booth.domain.BoothQrStrategy;
@@ -22,12 +23,15 @@ public class TokenBoothQrManager implements BoothQrManager {
   @Override
   public String generateBoothQr(final UUID boothId) {
     String encryptedToken = tokenUtil.getEncryptedToken(boothId.toString(), this.qrExpireTime);
-    return qrGenerator.generateQrCode("/booths/", encryptedToken, getQuery());
+    return qrGenerator.generateQrCode("/booths/",
+        Base64.getEncoder().encodeToString(encryptedToken.getBytes()),
+        getQuery());
   }
 
   @Override
   public UUID getBoothIdFromQrId(final String qrId) {
-    return UUID.fromString(tokenUtil.parseValue(qrId));
+    String base64Decoded = new String(Base64.getDecoder().decode(qrId));
+    return UUID.fromString(tokenUtil.parseValue(base64Decoded));
   }
 
   @Override

--- a/src/main/java/org/mju_likelion/festival/common/config/AuthenticationConfig.java
+++ b/src/main/java/org/mju_likelion/festival/common/config/AuthenticationConfig.java
@@ -24,7 +24,7 @@ public class AuthenticationConfig implements WebMvcConfigurer {
 
   @Override
   public void addInterceptors(final InterceptorRegistry registry) {
-    // addUserAuthenticationInterceptor(registry);
+    addUserAuthenticationInterceptor(registry);
     // addStudentCouncilAuthenticationInterceptor(registry);
     addBoothAdminAuthenticationInterceptor(registry);
     addAdminAuthenticationInterceptor(registry);
@@ -67,7 +67,7 @@ public class AuthenticationConfig implements WebMvcConfigurer {
    */
   private void addUserAuthenticationInterceptor(final InterceptorRegistry registry) {
     registry.addInterceptor(userAuthenticationInterceptor)
-        .addPathPatterns();
+        .addPathPatterns("/booths/{qrId}/visit");
   }
 
   @Override

--- a/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
@@ -38,10 +38,13 @@ public enum ErrorType {
   CREDENTIAL_KEY_NOT_FOUND_ERROR(4042, "자격 증명 키를 찾을 수 없습니다."),
   BOOTH_QR_NOT_FOUND_ERROR(4043, "해당 부스 QR을 찾을 수 없습니다."),
   ADMIN_NOT_FOUND_ERROR(4044, "해당 관리자를 찾을 수 없습니다."),
+  USER_NOT_FOUND_ERROR(4045, "해당 사용자를 찾을 수 없습니다."),
 
   METHOD_NOT_ALLOWED_ERROR(4050, "허용되지 않은 HTTP 메소드입니다."),
 
   HTTP_MEDIA_TYPE_NOT_ACCEPTABLE_ERROR(4060, "수락할 수 없는 미디어 타입입니다."),
+
+  ALREADY_VISITED_BOOTH(4090, "이미 방문한 부스입니다."),
 
   HTTP_MEDIA_TYPE_NOT_SUPPORTED_ERROR(4150, "지원하지 않는 미디어 타입입니다."),
 

--- a/src/main/java/org/mju_likelion/festival/user/domain/User.java
+++ b/src/main/java/org/mju_likelion/festival/user/domain/User.java
@@ -2,19 +2,15 @@ package org.mju_likelion.festival.user.domain;
 
 import static org.mju_likelion.festival.common.domain.constant.ColumnLengths.USER_STUDENT_ID_LENGTH;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.mju_likelion.festival.booth.domain.BoothUser;
+import org.mju_likelion.festival.booth.domain.Booth;
+import org.mju_likelion.festival.booth.domain.BoothUsers;
 import org.mju_likelion.festival.common.domain.BaseEntity;
 import org.mju_likelion.festival.term.domain.Term;
 import org.mju_likelion.festival.term.domain.TermUsers;
@@ -30,17 +26,21 @@ public class User extends BaseEntity {
   @Embedded
   private TermUsers termUsers;
 
-  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-  private List<BoothUser> boothUsers;
+  @Embedded
+  private BoothUsers boothUsers;
 
   public User(String studentId) {
     this.studentId = studentId;
     this.termUsers = new TermUsers();
-    this.boothUsers = new ArrayList<>();
+    this.boothUsers = new BoothUsers();
   }
 
   public void agreeToTerm(Term term) {
     this.termUsers.agree(term, this);
+  }
+
+  public void visitBooth(Booth booth) {
+    this.boothUsers.visit(this, booth);
   }
 
   @Override

--- a/src/test/java/org/mju_likelion/festival/booth/service/BoothServiceTest.java
+++ b/src/test/java/org/mju_likelion/festival/booth/service/BoothServiceTest.java
@@ -1,0 +1,150 @@
+package org.mju_likelion.festival.booth.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.willReturn;
+
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mju_likelion.festival.admin.domain.Admin;
+import org.mju_likelion.festival.admin.domain.repository.AdminJpaRepository;
+import org.mju_likelion.festival.booth.domain.Booth;
+import org.mju_likelion.festival.booth.domain.BoothQrStrategy;
+import org.mju_likelion.festival.booth.domain.BoothUser;
+import org.mju_likelion.festival.booth.domain.repository.BoothJpaRepository;
+import org.mju_likelion.festival.booth.domain.repository.BoothUserJpaRepository;
+import org.mju_likelion.festival.booth.dto.response.BoothQrResponse;
+import org.mju_likelion.festival.booth.util.qr.BoothQrManagerContext;
+import org.mju_likelion.festival.booth.util.qr.RedisBoothQrManager;
+import org.mju_likelion.festival.booth.util.qr.TokenBoothQrManager;
+import org.mju_likelion.festival.common.annotation.ApplicationTest;
+import org.mju_likelion.festival.common.exception.ConflictException;
+import org.mju_likelion.festival.common.exception.NotFoundException;
+import org.mju_likelion.festival.user.domain.User;
+import org.mju_likelion.festival.user.domain.repository.UserJpaRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@DisplayName("BoothService")
+@ApplicationTest
+public class BoothServiceTest {
+
+  @Autowired
+  private BoothService boothService;
+  @Autowired
+  private BoothQueryService boothQueryService;
+  @Autowired
+  private BoothJpaRepository boothJpaRepository;
+  @Autowired
+  private AdminJpaRepository adminJpaRepository;
+  @Autowired
+  private UserJpaRepository userJpaRepository;
+  @Autowired
+  private BoothUserJpaRepository boothUserJpaRepository;
+  @MockBean
+  private BoothQrManagerContext boothQrManagerContext;
+  @Autowired
+  private RedisBoothQrManager redisBoothQrManager;
+  @Autowired
+  private TokenBoothQrManager tokenBoothQrManager;
+  private User user;
+  private Booth booth;
+  private Admin admin;
+
+  @BeforeEach
+  void setUp() {
+    booth = boothJpaRepository.findAll().get(0);
+    user = userJpaRepository.findAll().get(0);
+    admin = adminJpaRepository.findByBoothId(booth.getId()).get();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    cleanUpBoothUser();
+  }
+
+  @DisplayName("RedisBoothQrManager 를 사용하여 발급받은 QR 코드를 통해 부스에 방문 처리를 한다.")
+  @Test
+  void testVisitBoothByQrCode() {
+    // given
+    willReturn(redisBoothQrManager).given(boothQrManagerContext).boothQrManager();
+    willReturn(redisBoothQrManager).given(boothQrManagerContext)
+        .boothQrManager(BoothQrStrategy.REDIS);
+
+    BoothQrResponse boothQrResponse = boothQueryService.getBoothQr(booth.getId(), admin.getId());
+    String qrId = getQrIdFromQrCode(boothQrResponse.getQrCode());
+
+    // when
+    boothService.visitBooth(qrId, BoothQrStrategy.REDIS, user.getId());
+
+    // then
+    Optional<BoothUser> boothUser = boothUserJpaRepository.findByUserAndBooth(user, booth);
+    assertThat(boothUser).isPresent();
+  }
+
+  @DisplayName("TokenBoothQrManager 를 사용하여 발급받은 QR 코드를 통해 부스에 방문 처리를 한다.")
+  @Test
+  void testVisitBoothByQrCodeWithTokenBoothQrManager() {
+    // given
+    willReturn(tokenBoothQrManager).given(boothQrManagerContext).boothQrManager();
+    willReturn(tokenBoothQrManager).given(boothQrManagerContext)
+        .boothQrManager(BoothQrStrategy.TOKEN);
+
+    BoothQrResponse boothQrResponse = boothQueryService.getBoothQr(booth.getId(), admin.getId());
+    String qrId = getQrIdFromQrCode(boothQrResponse.getQrCode());
+
+    // when
+    boothService.visitBooth(qrId, BoothQrStrategy.TOKEN, user.getId());
+
+    // then
+    Optional<BoothUser> boothUser = boothUserJpaRepository.findByUserAndBooth(user, booth);
+    assertThat(boothUser).isPresent();
+  }
+
+  @DisplayName("RedisBoothQrManager 를 사용하여 이미 방문한 부스의 QR 방문 처리를 하면 예외가 발생한다.")
+  @Test
+  void testVisitBoothByQrCodeAlreadyVisited() {
+    // given
+    willReturn(redisBoothQrManager).given(boothQrManagerContext).boothQrManager();
+    willReturn(redisBoothQrManager).given(boothQrManagerContext)
+        .boothQrManager(BoothQrStrategy.REDIS);
+
+    BoothQrResponse boothQrResponse = boothQueryService.getBoothQr(booth.getId(), admin.getId());
+    String qrId = getQrIdFromQrCode(boothQrResponse.getQrCode());
+
+    boothService.visitBooth(qrId, BoothQrStrategy.REDIS, user.getId());
+
+    // when & then
+    assertThatThrownBy(() -> boothService.visitBooth(qrId, BoothQrStrategy.REDIS, user.getId()))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @DisplayName("TokenBoothQrManager 를 사용하여 이미 방문한 부스의 QR 방문 처리를 하면 예외가 발생한다.")
+  @Test
+  void testVisitBoothByQrCodeAlreadyVisitedWithTokenBoothQrManager() {
+    // given
+    willReturn(tokenBoothQrManager).given(boothQrManagerContext).boothQrManager();
+    willReturn(tokenBoothQrManager).given(boothQrManagerContext)
+        .boothQrManager(BoothQrStrategy.TOKEN);
+
+    BoothQrResponse boothQrResponse = boothQueryService.getBoothQr(booth.getId(), admin.getId());
+    String qrId = getQrIdFromQrCode(boothQrResponse.getQrCode());
+    boothService.visitBooth(qrId, BoothQrStrategy.TOKEN, user.getId());
+
+    // when & then
+    assertThatThrownBy(() -> boothService.visitBooth(qrId, BoothQrStrategy.TOKEN, user.getId()))
+        .isInstanceOf(ConflictException.class);
+  }
+
+  private String getQrIdFromQrCode(String qrCode) {
+    return qrCode.split("/")[4].split("\\?")[0];
+  }
+
+  private void cleanUpBoothUser() {
+    Optional<BoothUser> boothUser = boothUserJpaRepository.findByUserAndBooth(user, booth);
+    boothUser.ifPresent(boothUserJpaRepository::delete);
+  }
+}


### PR DESCRIPTION
## Description
부스 QR 방문 처리 API 개발
## Changes
### List<BoothUser> 일급 컬렉션으로 포장
- [x] User
- [x] Booth
- [x] BoothUsers
### Booth QR 발급에서 Token 사용 시 Token을 Base64로 인코딩하도록
- [x] TokenBoothQrManager
### 테스트용 메서드 추가
- [x] AdminJpaRepository
- [x] BoothUserJpaRepository
### 테스트 작성
- [x] BoothServiceTest

### API
| URL                     | method | Usage                   | Authorization Needed |
| ------------------ | ---------| -------------------- | ------------------------ |
|         /booths/{qrId}/visit?strategy={strategy}                   |  POST             |             부스 QR 방문                  |                   O(사용자만)                 |

## Additional context
Closes #52 