### PR TITLE
Feature/#62 공지사항 전체 조회 API 구현

### DIFF
--- a/src/main/java/org/mju_likelion/festival/announcement/controller/AnnouncementController.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/controller/AnnouncementController.java
@@ -1,0 +1,29 @@
+package org.mju_likelion.festival.announcement.controller;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.announcement.dto.response.SimpleAnnouncementResponse;
+import org.mju_likelion.festival.announcement.service.AnnouncementQueryService;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/announcements")
+public class AnnouncementController {
+
+  private final AnnouncementQueryService announcementQueryService;
+
+  @GetMapping
+  public ResponseEntity<List<SimpleAnnouncementResponse>> getAnnouncements(
+      @RequestParam String sort,
+      @RequestParam int page, @RequestParam int size) {
+
+    return ResponseEntity.ok(
+        announcementQueryService.getAnnouncements(Direction.fromString(sort), page, size));
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/SimpleAnnouncement.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/SimpleAnnouncement.java
@@ -1,0 +1,14 @@
+package org.mju_likelion.festival.announcement.domain;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SimpleAnnouncement {
+
+  private final UUID id;
+  private final String title;
+  private final String content;
+}

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementQueryRepository.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementQueryRepository.java
@@ -1,0 +1,55 @@
+package org.mju_likelion.festival.announcement.domain.repository;
+
+import static org.mju_likelion.festival.common.util.uuid.UUIDUtil.hexToUUID;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.mju_likelion.festival.announcement.domain.SimpleAnnouncement;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AnnouncementQueryRepository {
+
+  private final RowMapper<SimpleAnnouncement> simpleAnnouncementRowMapper = simpleAnnouncementRowMapper();
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  private RowMapper<SimpleAnnouncement> simpleAnnouncementRowMapper() {
+    return (rs, rowNum) -> {
+      String hexId = rs.getString("announcementId");
+      UUID uuid = hexToUUID(hexId);
+      return new SimpleAnnouncement(
+          uuid,
+          rs.getString("title"),
+          rs.getString("content")
+      );
+    };
+  }
+
+  /**
+   * 페이지네이션을 적용하여 공지사항 간단 정보 List 조회.
+   *
+   * @param direction 정렬
+   * @param page      페이지
+   * @param size      크기
+   * @return 공지사항 간단 정보 List
+   */
+  public List<SimpleAnnouncement> findSimpleAnnouncements(Direction direction, final int page,
+      final int size) {
+    String sql = "SELECT HEX(a.id) AS announcementId, a.title AS title, a.content AS content "
+        + "FROM announcement a "
+        + "ORDER BY a.created_at " + direction.toString() + " "
+        + "LIMIT :limit OFFSET :offset";
+
+    MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("limit", size)
+        .addValue("offset", page * size);
+
+    return jdbcTemplate.query(sql, params, simpleAnnouncementRowMapper);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/announcement/dto/response/SimpleAnnouncementResponse.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/dto/response/SimpleAnnouncementResponse.java
@@ -1,0 +1,21 @@
+package org.mju_likelion.festival.announcement.dto.response;
+
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.mju_likelion.festival.announcement.domain.SimpleAnnouncement;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SimpleAnnouncementResponse {
+
+  private final UUID id;
+  private final String title;
+  private final String content;
+
+  public static SimpleAnnouncementResponse from(SimpleAnnouncement simpleAnnouncement) {
+    return new SimpleAnnouncementResponse(simpleAnnouncement.getId(), simpleAnnouncement.getTitle(),
+        simpleAnnouncement.getContent());
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/announcement/service/AnnouncementQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/service/AnnouncementQueryService.java
@@ -1,0 +1,23 @@
+package org.mju_likelion.festival.announcement.service;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.announcement.domain.repository.AnnouncementQueryRepository;
+import org.mju_likelion.festival.announcement.dto.response.SimpleAnnouncementResponse;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+@Transactional(readOnly = true)
+public class AnnouncementQueryService {
+
+  private final AnnouncementQueryRepository announcementQueryRepository;
+
+  public List<SimpleAnnouncementResponse> getAnnouncements(Direction sort, int page, int size) {
+    return announcementQueryRepository.findSimpleAnnouncements(sort, page, size).stream()
+        .map(SimpleAnnouncementResponse::from)
+        .toList();
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/auth/controller/AuthController.java
+++ b/src/main/java/org/mju_likelion/festival/auth/controller/AuthController.java
@@ -33,14 +33,16 @@ public class AuthController {
   @PostMapping("/user/login")
   public ResponseEntity<LoginResponse> userLogin(
       @RequestBody @Valid UserLoginRequest userLoginRequest,
-      @RequestParam RsaKeyStrategy rsaKeyStrategy) {
-    return ResponseEntity.ok(authService.userLogin(userLoginRequest, rsaKeyStrategy));
+      @RequestParam String rsaKeyStrategy) {
+    return ResponseEntity.ok(
+        authService.userLogin(userLoginRequest, RsaKeyStrategy.fromString(rsaKeyStrategy)));
   }
 
   @PostMapping("/admin/login")
   public ResponseEntity<LoginResponse> adminLogin(
       @RequestBody @Valid AdminLoginRequest adminLoginRequest,
-      @RequestParam RsaKeyStrategy rsaKeyStrategy) {
-    return ResponseEntity.ok(authQueryService.adminLogin(adminLoginRequest, rsaKeyStrategy));
+      @RequestParam String rsaKeyStrategy) {
+    return ResponseEntity.ok(
+        authQueryService.adminLogin(adminLoginRequest, RsaKeyStrategy.fromString(rsaKeyStrategy)));
   }
 }

--- a/src/main/java/org/mju_likelion/festival/auth/domain/RsaKeyStrategy.java
+++ b/src/main/java/org/mju_likelion/festival/auth/domain/RsaKeyStrategy.java
@@ -1,5 +1,9 @@
 package org.mju_likelion.festival.auth.domain;
 
+import static org.mju_likelion.festival.common.exception.type.ErrorType.INVALID_RSA_KEY_STRATEGY_ERROR;
+
+import org.mju_likelion.festival.common.exception.BadRequestException;
+
 /**
  * RSA Key 전략 Enum
  * <p>
@@ -7,5 +11,13 @@ package org.mju_likelion.festival.auth.domain;
  */
 public enum RsaKeyStrategy {
   REDIS, // Private Key 를 Redis 에 저장
-  TOKEN // Private Key 와 만료 시간을 Token 에 저장
+  TOKEN; // Private Key 와 만료 시간을 Token 에 저장
+
+  public static RsaKeyStrategy fromString(String value) {
+    try {
+      return valueOf(value.toUpperCase());
+    } catch (Exception e) {
+      throw new BadRequestException(INVALID_RSA_KEY_STRATEGY_ERROR, e.getMessage());
+    }
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
+++ b/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
@@ -46,9 +46,9 @@ public class BoothController {
 
   @PostMapping("/{qrId}/visit")
   public ResponseEntity<Void> visitBooth(@PathVariable final String qrId,
-      @RequestParam final BoothQrStrategy strategy,
+      @RequestParam final String strategy,
       @AuthenticationPrincipal final UUID userId) {
-    boothService.visitBooth(qrId, strategy, userId);
+    boothService.visitBooth(qrId, BoothQrStrategy.fromString(strategy), userId);
     return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/domain/BoothQrStrategy.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/BoothQrStrategy.java
@@ -1,8 +1,21 @@
 package org.mju_likelion.festival.booth.domain;
 
+import static org.mju_likelion.festival.common.exception.type.ErrorType.INVALID_BOOTH_QR_STRATEGY_ERROR;
+
+import org.mju_likelion.festival.common.exception.BadRequestException;
+
 /**
  * 부스 QR 전략을 나타내는 Enum.
  */
 public enum BoothQrStrategy {
-  REDIS, TOKEN
+  REDIS,
+  TOKEN;
+
+  public static BoothQrStrategy fromString(String value) {
+    try {
+      return valueOf(value.toUpperCase());
+    } catch (Exception e) {
+      throw new BadRequestException(INVALID_BOOTH_QR_STRATEGY_ERROR, e.getMessage());
+    }
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
@@ -14,6 +14,8 @@ public enum ErrorType {
   FILE_EMPTY_ERROR(40004, "파일이 비어있습니다."),
   FILE_NOT_IMAGE_ERROR(40005, "이미지 파일이 아닙니다."),
   FILE_SIZE_EXCEED_ERROR(40006, "파일 크기가 초과되었습니다."),
+  INVALID_RSA_KEY_STRATEGY_ERROR(40007, "유효하지 않은 RSA Key 전략입니다."),
+  INVALID_BOOTH_QR_STRATEGY_ERROR(40008, "유효하지 않은 부스 QR 전략입니다."),
 
   INVALID_CREDENTIALS_ERROR(40100, "아이디나 비밀번호가 일치하지 않습니다."),
   NOT_AUTHENTICATED_ERROR(40101, "인증되지 않았습니다."),


### PR DESCRIPTION
## Description
공지사항 전체 조회 API 구현

최신순, 오래된 순 페이지네이션 적용
## Changes
### 공지사항 전체 조회 Response DTO
- [x] SimpleAnnouncement
- [x] SimpleAnnouncementResponse
### Announcement Query Repository
- [x] AnnouncementQueryRepository

### API
| URL                     | method | Usage                   | Authorization Needed |
| ------------------ | ---------| -------------------- | ------------------------ |
|           /announcements?sort={}&page={}&size={}                 |     GET          |              공지사항 전체 조회                 |           X                         |

## Additional context
Closes #62 