### PR TITLE
 Feature/#66 Interceptor CORS 문제 해결

### DIFF
--- a/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/AbstractAuthenticationInterceptor.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/AbstractAuthenticationInterceptor.java
@@ -4,6 +4,7 @@ import static org.mju_likelion.festival.common.exception.type.ErrorType.JWT_NOT_
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Objects;
 import org.mju_likelion.festival.auth.util.jwt.JwtUtil;
 import org.mju_likelion.festival.auth.util.jwt.Payload;
 import org.mju_likelion.festival.common.authentication.AuthenticationContext;
@@ -27,6 +28,11 @@ public abstract class AbstractAuthenticationInterceptor implements HandlerInterc
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
       Object handler) {
+
+    if (isOptionsRequest(request)) {
+      return true;
+    }
+
     String accessToken = AuthorizationExtractor.extract(request)
         .orElseThrow(() -> new UnauthorizedException(JWT_NOT_FOUND_ERROR));
     Payload payload = userJwtUtil.getPayload(accessToken);
@@ -37,6 +43,11 @@ public abstract class AbstractAuthenticationInterceptor implements HandlerInterc
 
     authenticationContext.setPrincipal(payload.getId());
     return true;
+  }
+
+  // OPTIONS 는 허용
+  private boolean isOptionsRequest(HttpServletRequest request) {
+    return Objects.equals(request.getMethod(), "OPTIONS");
   }
 
   protected abstract boolean isAuthorized(Payload payload);


### PR DESCRIPTION
## Description
Interceptor CORS 문제 해결

현재 Interceptor 는 해당 URI의 모든 요청에 대한 JWT 검증을 수행하고 있음.
이 과정에서 CORS 용도의 OPTIONS 요청에도 JWT 검증을 수행했음.
OPTIONS 요청엔 JWT 헤더가 없으므로, CORS 문제가 발생.

OPTIONS 메서드에 대한 요청엔 항상 허용함으로써 해결.
## Changes
### 최상위 인증 인터셉터 수정
- [x] AbstractAuthenticationInterceptor

## Additional context
Closes #66 