### PR TITLE
Feature/#68 공지사항 단건 조회 API 개발

### DIFF
--- a/src/main/java/org/mju_likelion/festival/announcement/controller/AnnouncementController.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/controller/AnnouncementController.java
@@ -1,11 +1,14 @@
 package org.mju_likelion.festival.announcement.controller;
 
+import java.util.UUID;
 import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.announcement.dto.response.AnnouncementDetailResponse;
 import org.mju_likelion.festival.announcement.dto.response.SimpleAnnouncementsResponse;
 import org.mju_likelion.festival.announcement.service.AnnouncementQueryService;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,5 +27,11 @@ public class AnnouncementController {
 
     return ResponseEntity.ok(
         announcementQueryService.getAnnouncements(Direction.fromString(sort), page, size));
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<AnnouncementDetailResponse> getAnnouncement(@PathVariable UUID id) {
+
+    return ResponseEntity.ok(announcementQueryService.getAnnouncement(id));
   }
 }

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/AnnouncementDetail.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/AnnouncementDetail.java
@@ -1,0 +1,18 @@
+package org.mju_likelion.festival.announcement.domain;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 공지사항 상세 정보.
+ */
+@Getter
+@AllArgsConstructor
+public class AnnouncementDetail {
+
+  private final UUID id;
+  private final String title;
+  private final String content;
+  private final String imageUrl;
+}

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementQueryRepository.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementQueryRepository.java
@@ -1,11 +1,15 @@
 package org.mju_likelion.festival.announcement.domain.repository;
 
 import static org.mju_likelion.festival.common.util.uuid.UUIDUtil.hexToUUID;
+import static org.mju_likelion.festival.common.util.uuid.UUIDUtil.uuidToHex;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.mju_likelion.festival.announcement.domain.AnnouncementDetail;
 import org.mju_likelion.festival.announcement.domain.SimpleAnnouncement;
+import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -17,6 +21,7 @@ import org.springframework.stereotype.Repository;
 public class AnnouncementQueryRepository {
 
   private final RowMapper<SimpleAnnouncement> simpleAnnouncementRowMapper = simpleAnnouncementRowMapper();
+  private final RowMapper<AnnouncementDetail> announcementDetailRowMapper = announcementDetailRowMapper();
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
   private RowMapper<SimpleAnnouncement> simpleAnnouncementRowMapper() {
@@ -31,6 +36,19 @@ public class AnnouncementQueryRepository {
     };
   }
 
+  private RowMapper<AnnouncementDetail> announcementDetailRowMapper() {
+    return (rs, rowNum) -> {
+      String hexId = rs.getString("announcementId");
+      UUID uuid = hexToUUID(hexId);
+      return new AnnouncementDetail(
+          uuid,
+          rs.getString("title"),
+          rs.getString("content"),
+          rs.getString("imageUrl")
+      );
+    };
+  }
+
   /**
    * 페이지네이션을 적용하여 공지사항 간단 정보 List 조회.
    *
@@ -39,7 +57,8 @@ public class AnnouncementQueryRepository {
    * @param size      크기
    * @return 공지사항 간단 정보 List
    */
-  public List<SimpleAnnouncement> findSimpleAnnouncements(Direction direction, final int page,
+  public List<SimpleAnnouncement> findOrderedSimpleAnnouncementsWithPagenation(Direction direction,
+      final int page,
       final int size) {
     String sql = "SELECT HEX(a.id) AS announcementId, a.title AS title, a.content AS content "
         + "FROM announcement a "
@@ -51,6 +70,27 @@ public class AnnouncementQueryRepository {
         .addValue("offset", page * size);
 
     return jdbcTemplate.query(sql, params, simpleAnnouncementRowMapper);
+  }
+
+  /**
+   * 공지사항 상세 정보 조회.
+   *
+   * @param id 공지사항 ID
+   */
+  public Optional<AnnouncementDetail> findAnnouncementById(final UUID id) {
+    String sql =
+        "SELECT HEX(a.id) AS announcementId, a.title AS title, a.content AS content,  i.url AS imageUrl "
+            + "FROM announcement a "
+            + "LEFT JOIN image i ON a.image_id = i.id "
+            + "WHERE a.id = UNHEX(:id)";
+
+    MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("id", uuidToHex(id));
+
+    return Optional
+        .ofNullable(
+            DataAccessUtils.singleResult(
+                jdbcTemplate.query(sql, params, announcementDetailRowMapper)));
   }
 
   /**

--- a/src/main/java/org/mju_likelion/festival/announcement/dto/response/AnnouncementDetailResponse.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/dto/response/AnnouncementDetailResponse.java
@@ -1,0 +1,31 @@
+package org.mju_likelion.festival.announcement.dto.response;
+
+
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.mju_likelion.festival.announcement.domain.AnnouncementDetail;
+
+/**
+ * 공지사항 상세 응답 DTO.
+ */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AnnouncementDetailResponse {
+
+  private final UUID id;
+  private final String title;
+  private final String content;
+  private final String imageUrl;
+
+  public static AnnouncementDetailResponse from(final AnnouncementDetail announcementDetail) {
+
+    return new AnnouncementDetailResponse(
+        announcementDetail.getId(),
+        announcementDetail.getTitle(),
+        announcementDetail.getContent(),
+        announcementDetail.getImageUrl()
+    );
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/announcement/service/AnnouncementQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/service/AnnouncementQueryService.java
@@ -1,11 +1,14 @@
 package org.mju_likelion.festival.announcement.service;
 
+import static org.mju_likelion.festival.common.exception.type.ErrorType.ANNOUNCEMENT_NOT_FOUND_ERROR;
 import static org.mju_likelion.festival.common.exception.type.ErrorType.PAGE_OUT_OF_BOUND_ERROR;
 
 import java.util.List;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.mju_likelion.festival.announcement.domain.SimpleAnnouncement;
 import org.mju_likelion.festival.announcement.domain.repository.AnnouncementQueryRepository;
+import org.mju_likelion.festival.announcement.dto.response.AnnouncementDetailResponse;
 import org.mju_likelion.festival.announcement.dto.response.SimpleAnnouncementsResponse;
 import org.mju_likelion.festival.common.exception.NotFoundException;
 import org.springframework.data.domain.Sort.Direction;
@@ -26,9 +29,17 @@ public class AnnouncementQueryService {
     validatePage(page, totalPage);
 
     List<SimpleAnnouncement> simpleAnnouncements = announcementQueryRepository
-        .findSimpleAnnouncements(sort, page, size);
+        .findOrderedSimpleAnnouncementsWithPagenation(sort, page, size);
 
     return SimpleAnnouncementsResponse.from(simpleAnnouncements, totalPage);
+  }
+
+  public AnnouncementDetailResponse getAnnouncement(UUID id) {
+    return AnnouncementDetailResponse.from(
+        announcementQueryRepository.findAnnouncementById(id).orElseThrow(
+            () -> new NotFoundException(ANNOUNCEMENT_NOT_FOUND_ERROR)
+        )
+    );
   }
 
   private void validatePage(int page, int totalPage) {

--- a/src/main/java/org/mju_likelion/festival/common/exception/controller/ExceptionController.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/controller/ExceptionController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
@@ -37,6 +38,17 @@ public class ExceptionController {
 
     BadRequestException badRequestException = new BadRequestException(
         ErrorType.INVALID_REQUEST_BODY_ERROR, message);
+
+    writeLog(badRequestException);
+    return ResponseEntity.badRequest().body(ErrorResponse.res(badRequestException));
+  }
+
+  // MethodArgumentTypeMismatchException 예외를 처리하는 핸들러 (요청 파라메터의 타입이 잘못된 경우)
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ErrorResponse> methodArgumentTypeMismatchExceptionHandler(
+      final MethodArgumentTypeMismatchException e) {
+    BadRequestException badRequestException = new BadRequestException(
+        ErrorType.INVALID_REQUEST_PARAMETER_ERROR, e.getName());
 
     writeLog(badRequestException);
     return ResponseEntity.badRequest().body(ErrorResponse.res(badRequestException));

--- a/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
@@ -16,6 +16,7 @@ public enum ErrorType {
   FILE_SIZE_EXCEED_ERROR(40006, "파일 크기가 초과되었습니다."),
   INVALID_RSA_KEY_STRATEGY_ERROR(40007, "유효하지 않은 RSA Key 전략입니다."),
   INVALID_BOOTH_QR_STRATEGY_ERROR(40008, "유효하지 않은 부스 QR 전략입니다."),
+  INVALID_REQUEST_PARAMETER_ERROR(40009, "요청 파라미터가 잘못되었습니다."),
 
   INVALID_CREDENTIALS_ERROR(40100, "아이디나 비밀번호가 일치하지 않습니다."),
   NOT_AUTHENTICATED_ERROR(40101, "인증되지 않았습니다."),
@@ -37,6 +38,7 @@ public enum ErrorType {
   ADMIN_NOT_FOUND_ERROR(40404, "해당 관리자를 찾을 수 없습니다."),
   USER_NOT_FOUND_ERROR(40405, "해당 사용자를 찾을 수 없습니다."),
   PAGE_OUT_OF_BOUND_ERROR(40406, "페이지 범위를 벗어났습니다."),
+  ANNOUNCEMENT_NOT_FOUND_ERROR(40407, "해당 공지사항을 찾을 수 없습니다."),
 
   METHOD_NOT_ALLOWED_ERROR(40500, "허용되지 않은 HTTP 메소드입니다."),
 

--- a/src/test/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementQueryRepositoryTest.java
+++ b/src/test/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementQueryRepositoryTest.java
@@ -1,0 +1,132 @@
+package org.mju_likelion.festival.announcement.domain.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mju_likelion.festival.announcement.domain.Announcement;
+import org.mju_likelion.festival.announcement.domain.AnnouncementDetail;
+import org.mju_likelion.festival.announcement.domain.SimpleAnnouncement;
+import org.mju_likelion.festival.common.annotation.ApplicationTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("AnnouncementQueryRepository")
+@ApplicationTest
+@Transactional(readOnly = true)
+public class AnnouncementQueryRepositoryTest {
+
+  @Autowired
+  private AnnouncementJpaRepository announcementJpaRepository;
+
+  @Autowired
+  private DataSource dataSource;
+
+  private AnnouncementQueryRepository announcementQueryRepository;
+
+  private int totalAnnouncementNum;
+
+  @BeforeEach
+  void setUp() {
+    announcementQueryRepository = new AnnouncementQueryRepository(
+        new NamedParameterJdbcTemplate(dataSource));
+    totalAnnouncementNum = (int) announcementJpaRepository.count();
+  }
+
+  @DisplayName("공지사항 간단 정보 List 조회 - 페이지네이션 ( 생성 시간 오름차순 )")
+  @Test
+  void testFindOrderedSimpleAnnouncementsWithPagination() {
+    // given
+    int pageSize = 5;
+    int totalPages = calculateTotalPages(totalAnnouncementNum, pageSize);
+
+    // when & then
+    IntStream.range(0, totalPages).forEach(page -> {
+      List<SimpleAnnouncement> pageContent = announcementQueryRepository.findOrderedSimpleAnnouncementsWithPagenation(
+          Direction.ASC, page, pageSize);
+
+      int expectedSize = calculateExpectedSize(page, pageSize, totalAnnouncementNum);
+
+      assertAll(
+          () -> {
+            assertThat(pageContent).isSortedAccordingTo(
+                (a, b) -> announcementJpaRepository.findById(a.getId()).get().getCreatedAt()
+                    .compareTo(announcementJpaRepository.findById(b.getId()).get().getCreatedAt()));
+
+            assertThat(pageContent)
+                .hasSize(expectedSize)
+                .withFailMessage("For page %d, expected size %d but got %d", page, expectedSize,
+                    pageContent.size());
+          }
+      );
+    });
+  }
+
+  @DisplayName("공지사항 간단 정보 List 조회 - 페이지네이션 ( 생성 시간 내림차순 )")
+  @Test
+  void testFindOrderedSimpleAnnouncementsWithPaginationDesc() {
+    // given
+    int pageSize = 5;
+    int totalPages = calculateTotalPages(totalAnnouncementNum, pageSize);
+
+    // when & then
+    IntStream.range(0, totalPages).forEach(page -> {
+      List<SimpleAnnouncement> pageContent = announcementQueryRepository.findOrderedSimpleAnnouncementsWithPagenation(
+          Direction.DESC, page, pageSize);
+
+      int expectedSize = calculateExpectedSize(page, pageSize, totalAnnouncementNum);
+
+      assertAll(
+          () -> {
+            assertThat(pageContent).isSortedAccordingTo(
+                (a, b) -> announcementJpaRepository.findById(b.getId()).get().getCreatedAt()
+                    .compareTo(announcementJpaRepository.findById(a.getId()).get().getCreatedAt()));
+
+            assertThat(pageContent)
+                .hasSize(expectedSize)
+                .withFailMessage("For page %d, expected size %d but got %d", page, expectedSize,
+                    pageContent.size());
+          }
+      );
+    });
+  }
+
+  @DisplayName("공지사항 상세 정보 조회")
+  @Test
+  void testFindAnnouncementDetail() {
+    // given
+    Announcement announcement = announcementJpaRepository.findAll().get(0);
+    // when
+    Optional<AnnouncementDetail> optionalAnnouncementDetail = announcementQueryRepository.findAnnouncementById(
+        announcement.getId());
+    // then
+    assertThat(optionalAnnouncementDetail)
+        .isPresent()
+        .hasValueSatisfying(announcementDetail ->
+            assertThat(announcementDetail.getId()).isEqualTo(announcement.getId())
+        );
+  }
+
+  private int calculateTotalPages(int totalItems, int pageSize) {
+    return (totalItems + pageSize - 1) / pageSize;
+  }
+
+  private int calculateExpectedSize(int page, int pageSize, int totalBoothNum) {
+    if (isLastPage(page, totalBoothNum, pageSize)) {
+      return totalBoothNum % pageSize == 0 ? pageSize : totalBoothNum % pageSize;
+    }
+    return pageSize;
+  }
+
+  private boolean isLastPage(int page, int totalBoothNum, int pageSize) {
+    return page == calculateTotalPages(totalBoothNum, pageSize) - 1;
+  }
+}


### PR DESCRIPTION
## Description
공지사항 단건 조회 API 개발

## Changes
### 공지사항 상세 조회 함수 추가
- [x] AnnouncementQueryRepository
- [x] AnnouncementQueryRepository
### 테스트 코드 작성 
- [x] AnnouncementQueryRepositoryTest

### API
| URL                     | method | Usage                   | Authorization Needed |
| ------------------ | ---------| -------------------- | ------------------------ |
|           /announcements/{id}                 |      GET         |              공지사항 단건 조회                 |                   X                 |

## Additional context
Closes #68 