### PR TITLE
Feature/#72 공지사항 작성 API 개발

### DIFF
--- a/src/main/java/org/mju_likelion/festival/admin/domain/Admin.java
+++ b/src/main/java/org/mju_likelion/festival/admin/domain/Admin.java
@@ -12,20 +12,19 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.mju_likelion.festival.announcement.domain.Announcement;
-import org.mju_likelion.festival.booth.domain.Booth;
 import org.mju_likelion.festival.common.domain.BaseEntity;
 import org.mju_likelion.festival.lost_item.domain.LostItem;
 
 @Getter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity(name = "admin")
 public class Admin extends BaseEntity {
@@ -43,16 +42,9 @@ public class Admin extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private AdminRole role;
 
-  @OneToOne(mappedBy = "owner", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
-  private Booth booth;
-
   @OneToMany(mappedBy = "writer", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
   private List<LostItem> lostItems;
 
   @OneToMany(mappedBy = "writer", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
   private List<Announcement> announcements;
-
-  public boolean isOwner(final Booth booth) {
-    return this.booth.equals(booth);
-  }
 }

--- a/src/main/java/org/mju_likelion/festival/admin/domain/repository/AdminJpaRepository.java
+++ b/src/main/java/org/mju_likelion/festival/admin/domain/repository/AdminJpaRepository.java
@@ -17,9 +17,4 @@ public interface AdminJpaRepository extends JpaRepository<Admin, UUID> {
    * @return Admin
    */
   Optional<Admin> findByLoginIdAndPassword(String loginId, String password);
-
-  /**
-   * 부스 ID 로 Admin 조회.
-   */
-  Optional<Admin> findByBoothId(UUID boothId);
 }

--- a/src/main/java/org/mju_likelion/festival/announcement/controller/AnnouncementController.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/controller/AnnouncementController.java
@@ -1,14 +1,20 @@
 package org.mju_likelion.festival.announcement.controller;
 
+import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.announcement.dto.request.CreateAnnouncementRequest;
 import org.mju_likelion.festival.announcement.dto.response.AnnouncementDetailResponse;
 import org.mju_likelion.festival.announcement.dto.response.SimpleAnnouncementsResponse;
 import org.mju_likelion.festival.announcement.service.AnnouncementQueryService;
+import org.mju_likelion.festival.announcement.service.AnnouncementService;
+import org.mju_likelion.festival.common.authentication.AuthenticationPrincipal;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AnnouncementController {
 
   private final AnnouncementQueryService announcementQueryService;
+  private final AnnouncementService qnnouncementService;
 
   @GetMapping
   public ResponseEntity<SimpleAnnouncementsResponse> getAnnouncements(
@@ -33,5 +40,14 @@ public class AnnouncementController {
   public ResponseEntity<AnnouncementDetailResponse> getAnnouncement(@PathVariable UUID id) {
 
     return ResponseEntity.ok(announcementQueryService.getAnnouncement(id));
+  }
+
+  @PostMapping
+  public ResponseEntity<Void> createAnnouncement(
+      @RequestBody @Valid CreateAnnouncementRequest createAnnouncementRequest,
+      @AuthenticationPrincipal UUID adminId) {
+
+    qnnouncementService.createAnnouncement(createAnnouncementRequest, adminId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/Announcement.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/Announcement.java
@@ -2,6 +2,8 @@ package org.mju_likelion.festival.announcement.domain;
 
 import static org.mju_likelion.festival.common.domain.constant.ColumnLengths.ANNOUNCEMENT_CONTENT_LENGTH;
 import static org.mju_likelion.festival.common.domain.constant.ColumnLengths.ANNOUNCEMENT_TITLE_LENGTH;
+import static org.mju_likelion.festival.common.exception.type.ErrorType.INVALID_CONTENT_LENGTH_ERROR;
+import static org.mju_likelion.festival.common.exception.type.ErrorType.INVALID_TITLE_LENGTH_ERROR;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -10,18 +12,16 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.mju_likelion.festival.admin.domain.Admin;
 import org.mju_likelion.festival.common.domain.BaseEntity;
+import org.mju_likelion.festival.common.exception.BadRequestException;
+import org.mju_likelion.festival.common.util.string.StringUtil;
 import org.mju_likelion.festival.image.domain.Image;
 
 @Getter
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
 @Entity(name = "announcement")
 public class Announcement extends BaseEntity {
 
@@ -38,4 +38,34 @@ public class Announcement extends BaseEntity {
   @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinColumn(name = "image_id")
   private Image image;
+
+  public Announcement(
+      final String title,
+      final String content,
+      final Image image,
+      final Admin writer) {
+
+    validate(title, content);
+    this.title = title;
+    this.content = content;
+    this.image = image;
+    this.writer = writer;
+  }
+
+  private void validate(final String title, final String content) {
+    validateTitle(title);
+    validateContent(content);
+  }
+
+  private void validateTitle(final String title) {
+    if (StringUtil.isEmptyOrLargerThan(title, ANNOUNCEMENT_TITLE_LENGTH)) {
+      throw new BadRequestException(INVALID_TITLE_LENGTH_ERROR);
+    }
+  }
+
+  private void validateContent(final String content) {
+    if (StringUtil.isEmptyOrLargerThan(content, ANNOUNCEMENT_CONTENT_LENGTH)) {
+      throw new BadRequestException(INVALID_CONTENT_LENGTH_ERROR);
+    }
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/announcement/dto/request/CreateAnnouncementRequest.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/dto/request/CreateAnnouncementRequest.java
@@ -1,0 +1,19 @@
+package org.mju_likelion.festival.announcement.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+/**
+ * 공지사항 생성 요청 DTO
+ */
+@Getter
+public class CreateAnnouncementRequest {
+
+  @NotNull(message = "제목은 필수 입력값입니다.")
+  private String title;
+
+  @NotNull(message = "내용은 필수 입력값입니다.")
+  private String content;
+
+  private String imageUrl;
+}

--- a/src/main/java/org/mju_likelion/festival/announcement/service/AnnouncementService.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/service/AnnouncementService.java
@@ -1,0 +1,49 @@
+package org.mju_likelion.festival.announcement.service;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.ADMIN_NOT_FOUND_ERROR;
+
+import java.util.Optional;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.admin.domain.Admin;
+import org.mju_likelion.festival.admin.domain.repository.AdminJpaRepository;
+import org.mju_likelion.festival.announcement.domain.Announcement;
+import org.mju_likelion.festival.announcement.domain.repository.AnnouncementJpaRepository;
+import org.mju_likelion.festival.announcement.dto.request.CreateAnnouncementRequest;
+import org.mju_likelion.festival.booth.domain.repository.BoothJpaRepository;
+import org.mju_likelion.festival.common.exception.NotFoundException;
+import org.mju_likelion.festival.image.domain.Image;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class AnnouncementService {
+
+  private final AnnouncementJpaRepository announcementJpaRepository;
+  private final AdminJpaRepository adminJpaRepository;
+  private final BoothJpaRepository boothJpaRepository;
+
+  public void createAnnouncement(CreateAnnouncementRequest createAnnouncementRequest,
+      UUID adminId) {
+
+    Admin admin = getExistingAdmin(adminId);
+
+    Image image = Optional.ofNullable(createAnnouncementRequest.getImageUrl())
+        .map(Image::new)
+        .orElse(null);
+
+    Announcement announcement = new Announcement(
+        createAnnouncementRequest.getTitle(),
+        createAnnouncementRequest.getContent(),
+        image,
+        admin
+    );
+
+    announcementJpaRepository.save(announcement);
+  }
+
+  public Admin getExistingAdmin(UUID adminId) {
+    return adminJpaRepository.findById(adminId)
+        .orElseThrow(() -> new NotFoundException(ADMIN_NOT_FOUND_ERROR));
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
@@ -48,4 +48,8 @@ public class Booth extends BaseEntity {
   @OneToOne(optional = false, fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinColumn(nullable = false, name = "image_id")
   private Image image;
+
+  public boolean isManagedBy(Admin admin) {
+    return owner.equals(admin);
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
@@ -72,7 +72,7 @@ public class BoothQueryService {
   }
 
   private void validateBoothAdminOwner(Admin admin, Booth booth) {
-    if (!admin.isOwner(booth)) {
+    if (!booth.isManagedBy(admin)) {
       throw new ForbiddenException(NOT_BOOTH_OWNER_ERROR);
     }
   }

--- a/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/StudentCouncilAuthenticationInterceptor.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/StudentCouncilAuthenticationInterceptor.java
@@ -2,12 +2,16 @@ package org.mju_likelion.festival.common.authentication.interceptor;
 
 import static org.mju_likelion.festival.common.exception.type.ErrorType.STUDENT_COUNCIL_ONLY_ERROR;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
 import org.mju_likelion.festival.auth.util.jwt.AuthenticationRole;
 import org.mju_likelion.festival.auth.util.jwt.JwtUtil;
 import org.mju_likelion.festival.auth.util.jwt.Payload;
 import org.mju_likelion.festival.common.authentication.AuthenticationContext;
+import org.mju_likelion.festival.common.config.RequestMatcher;
 import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,6 +20,15 @@ public class StudentCouncilAuthenticationInterceptor extends AbstractAuthenticat
   public StudentCouncilAuthenticationInterceptor(AuthenticationContext authenticationContext,
       JwtUtil userJwtUtil) {
     super(authenticationContext, userJwtUtil);
+  }
+
+  @Override
+  protected List<RequestMatcher> getAllowedRequestMatchers() {
+    List<RequestMatcher> allowedRequestMatchers = new LinkedList<>();
+    allowedRequestMatchers.add(new RequestMatcher(HttpMethod.GET, "/announcements"));
+    allowedRequestMatchers.add(new RequestMatcher(HttpMethod.GET, "/announcements/{id}"));
+
+    return allowedRequestMatchers;
   }
 
   @Override

--- a/src/main/java/org/mju_likelion/festival/common/config/AuthenticationConfig.java
+++ b/src/main/java/org/mju_likelion/festival/common/config/AuthenticationConfig.java
@@ -25,7 +25,7 @@ public class AuthenticationConfig implements WebMvcConfigurer {
   @Override
   public void addInterceptors(final InterceptorRegistry registry) {
     addUserAuthenticationInterceptor(registry);
-    // addStudentCouncilAuthenticationInterceptor(registry);
+    addStudentCouncilAuthenticationInterceptor(registry);
     addBoothAdminAuthenticationInterceptor(registry);
     addAdminAuthenticationInterceptor(registry);
   }
@@ -47,7 +47,7 @@ public class AuthenticationConfig implements WebMvcConfigurer {
    */
   private void addStudentCouncilAuthenticationInterceptor(final InterceptorRegistry registry) {
     registry.addInterceptor(studentCouncilAuthenticationInterceptor)
-        .addPathPatterns();
+        .addPathPatterns("/announcements");
   }
 
   /**

--- a/src/main/java/org/mju_likelion/festival/common/config/RequestMatcher.java
+++ b/src/main/java/org/mju_likelion/festival/common/config/RequestMatcher.java
@@ -1,0 +1,27 @@
+package org.mju_likelion.festival.common.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.util.UriTemplate;
+
+/**
+ * 요청 매칭을 위한 클래스
+ */
+@AllArgsConstructor
+public class RequestMatcher {
+
+  private final HttpMethod method;
+  private final String path;
+
+  /**
+   * 요청이 매칭되는지 확인한다.
+   *
+   * @param request 요청
+   * @return 매칭 여부
+   */
+  public boolean matches(HttpServletRequest request) {
+    UriTemplate template = new UriTemplate(path);
+    return method.matches(request.getMethod()) && template.matches(request.getRequestURI());
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/domain/constant/ColumnLengths.java
+++ b/src/main/java/org/mju_likelion/festival/common/domain/constant/ColumnLengths.java
@@ -20,8 +20,8 @@ public abstract class ColumnLengths {
   public static final int BOOTH_DESCRIPTION_LENGTH = 4000;
   public static final int BOOTH_LOCATION_LENGTH = 100;
 
-  public static final int ANNOUNCEMENT_TITLE_LENGTH = 100;
-  public static final int ANNOUNCEMENT_CONTENT_LENGTH = 4000;
+  public static final int ANNOUNCEMENT_TITLE_LENGTH = 50;
+  public static final int ANNOUNCEMENT_CONTENT_LENGTH = 100;
 
   public static final int USER_STUDENT_ID_LENGTH = 8;
 }

--- a/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
@@ -17,6 +17,9 @@ public enum ErrorType {
   INVALID_RSA_KEY_STRATEGY_ERROR(40007, "유효하지 않은 RSA Key 전략입니다."),
   INVALID_BOOTH_QR_STRATEGY_ERROR(40008, "유효하지 않은 부스 QR 전략입니다."),
   INVALID_REQUEST_PARAMETER_ERROR(40009, "요청 파라미터가 잘못되었습니다."),
+  INVALID_TITLE_LENGTH_ERROR(40010, "올바르지 않은 제목 길이입니다."),
+  INVALID_CONTENT_LENGTH_ERROR(40011, "올바르지 않은 내용 길이입니다."),
+  INVALID_IMAGE_URL_LENGTH_ERROR(40012, "올바르지 않은 이미지 URL 길이입니다."),
 
   INVALID_CREDENTIALS_ERROR(40100, "아이디나 비밀번호가 일치하지 않습니다."),
   NOT_AUTHENTICATED_ERROR(40101, "인증되지 않았습니다."),

--- a/src/main/java/org/mju_likelion/festival/common/util/string/StringUtil.java
+++ b/src/main/java/org/mju_likelion/festival/common/util/string/StringUtil.java
@@ -1,0 +1,11 @@
+package org.mju_likelion.festival.common.util.string;
+
+/**
+ * 문자열 유틸 클래스
+ */
+public class StringUtil {
+
+  public static boolean isEmptyOrLargerThan(String str, int length) {
+    return str.isEmpty() || str.length() > length;
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/image/domain/Image.java
+++ b/src/main/java/org/mju_likelion/festival/image/domain/Image.java
@@ -1,40 +1,33 @@
 package org.mju_likelion.festival.image.domain;
 
 import static org.mju_likelion.festival.common.domain.constant.ColumnLengths.IMAGE_URL_LENGTH;
+import static org.mju_likelion.festival.common.exception.type.ErrorType.INVALID_IMAGE_URL_LENGTH_ERROR;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.mju_likelion.festival.announcement.domain.Announcement;
-import org.mju_likelion.festival.booth.domain.Booth;
 import org.mju_likelion.festival.common.domain.BaseEntity;
-import org.mju_likelion.festival.lost_item.domain.LostItem;
+import org.mju_likelion.festival.common.exception.BadRequestException;
+import org.mju_likelion.festival.common.util.string.StringUtil;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "image")
 public class Image extends BaseEntity {
 
-  @OneToOne(mappedBy = "image", fetch = FetchType.LAZY)
-  private Booth boothThumbnail;
-
-  @OneToOne(mappedBy = "image", fetch = FetchType.LAZY)
-  private Booth boothImage;
-
-  @OneToOne(mappedBy = "image", fetch = FetchType.LAZY)
-  private LostItem lostItem;
-
-  @OneToOne(mappedBy = "image", fetch = FetchType.LAZY)
-  private Announcement announcement;
-
-  @Column(nullable = false, length = IMAGE_URL_LENGTH, unique = true)
+  @Column(nullable = false, length = IMAGE_URL_LENGTH)
   private String url;
 
   public Image(String url) {
+    validateUrl(url);
     this.url = url;
+  }
+
+  public void validateUrl(String url) {
+    if (StringUtil.isEmptyOrLargerThan(url, IMAGE_URL_LENGTH)) {
+      throw new BadRequestException(INVALID_IMAGE_URL_LENGTH_ERROR);
+    }
   }
 }

--- a/src/test/java/org/mju_likelion/festival/booth/service/BoothServiceTest.java
+++ b/src/test/java/org/mju_likelion/festival/booth/service/BoothServiceTest.java
@@ -58,7 +58,7 @@ public class BoothServiceTest {
   void setUp() {
     booth = boothJpaRepository.findAll().get(0);
     user = userJpaRepository.findAll().get(0);
-    admin = adminJpaRepository.findByBoothId(booth.getId()).get();
+    admin = booth.getOwner();
   }
 
   @AfterEach


### PR DESCRIPTION
## Description
공지사항 작성 API 개발
## Changes
### 공지사항 title, content 컬럼 길이 변경
- [x] ColumnLengths
### Entity 간 @OneToOne 양방향 매핑 제거 - 필요하지 않다고 판단
- [x] Image - Booth
- [x] Image - LostItem
- [x] Image - Announcement
- [x] Admin - Booth
### 인터셉터 URI 중복 문제
- [x] RequestMatcher
- [x] AbstractAuthenticationInterceptor
### Service
- [x] AnnouncementService
### Controller
- [x] AnnouncementController

### API
| URL                     | method | Usage                   | Authorization Needed |
| ------------------ | ---------| -------------------- | ------------------------ |
|             /announcements               |     POST         |             공지사항 작성                  |                 O(학생회만)                   |

## Additional context
Closes #72 