### PR TITLE
Feature/#74 공지사항 수정 API 개발

### DIFF
--- a/src/main/java/org/mju_likelion/festival/announcement/controller/AnnouncementController.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/controller/AnnouncementController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.mju_likelion.festival.announcement.dto.request.CreateAnnouncementRequest;
+import org.mju_likelion.festival.announcement.dto.request.UpdateAnnouncementRequest;
 import org.mju_likelion.festival.announcement.dto.response.AnnouncementDetailResponse;
 import org.mju_likelion.festival.announcement.dto.response.SimpleAnnouncementsResponse;
 import org.mju_likelion.festival.announcement.service.AnnouncementQueryService;
@@ -12,6 +13,7 @@ import org.mju_likelion.festival.common.authentication.AuthenticationPrincipal;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -48,6 +50,16 @@ public class AnnouncementController {
       @AuthenticationPrincipal UUID adminId) {
 
     qnnouncementService.createAnnouncement(createAnnouncementRequest, adminId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @PatchMapping("/{id}")
+  public ResponseEntity<Void> updateAnnouncement(
+      @PathVariable UUID id,
+      @RequestBody @Valid UpdateAnnouncementRequest updateAnnouncementRequest,
+      @AuthenticationPrincipal UUID adminId) {
+
+    qnnouncementService.updateAnnouncement(id, updateAnnouncementRequest, adminId);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/Announcement.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/Announcement.java
@@ -52,6 +52,20 @@ public class Announcement extends BaseEntity {
     this.writer = writer;
   }
 
+  public void updateTitle(final String title) {
+    validateTitle(title);
+    this.title = title;
+  }
+
+  public void updateContent(final String content) {
+    validateContent(content);
+    this.content = content;
+  }
+
+  public void updateImage(final Image image) {
+    this.image = image;
+  }
+
   private void validate(final String title, final String content) {
     validateTitle(title);
     validateContent(content);

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/Announcement.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/Announcement.java
@@ -25,10 +25,6 @@ import org.mju_likelion.festival.image.domain.Image;
 @Entity(name = "announcement")
 public class Announcement extends BaseEntity {
 
-  @ManyToOne(optional = false, fetch = FetchType.LAZY)
-  @JoinColumn(name = "writer_id")
-  private Admin writer;
-
   @Column(nullable = false, length = ANNOUNCEMENT_TITLE_LENGTH)
   private String title;
 
@@ -38,6 +34,10 @@ public class Announcement extends BaseEntity {
   @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinColumn(name = "image_id")
   private Image image;
+
+  @ManyToOne(optional = false, fetch = FetchType.LAZY)
+  @JoinColumn(name = "writer_id")
+  private Admin writer;
 
   public Announcement(
       final String title,
@@ -58,13 +58,13 @@ public class Announcement extends BaseEntity {
   }
 
   private void validateTitle(final String title) {
-    if (StringUtil.isEmptyOrLargerThan(title, ANNOUNCEMENT_TITLE_LENGTH)) {
+    if (StringUtil.isBlankOrLargerThan(title, ANNOUNCEMENT_TITLE_LENGTH)) {
       throw new BadRequestException(INVALID_TITLE_LENGTH_ERROR);
     }
   }
 
   private void validateContent(final String content) {
-    if (StringUtil.isEmptyOrLargerThan(content, ANNOUNCEMENT_CONTENT_LENGTH)) {
+    if (StringUtil.isBlankOrLargerThan(content, ANNOUNCEMENT_CONTENT_LENGTH)) {
       throw new BadRequestException(INVALID_CONTENT_LENGTH_ERROR);
     }
   }

--- a/src/main/java/org/mju_likelion/festival/announcement/dto/request/UpdateAnnouncementRequest.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/dto/request/UpdateAnnouncementRequest.java
@@ -1,0 +1,22 @@
+package org.mju_likelion.festival.announcement.dto.request;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.Getter;
+import lombok.Setter;
+import org.mju_likelion.festival.announcement.util.deserializer.UpdateAnnouncementRequestDeserializer;
+import org.mju_likelion.festival.common.util.field_wrapper.FieldWrapper;
+
+/**
+ * 공지사항 수정 요청 DTO
+ * <p>
+ * PATCH 를 처리하기 위해 FieldWrapper 를 사용한다.
+ */
+@Getter
+@Setter
+@JsonDeserialize(using = UpdateAnnouncementRequestDeserializer.class)
+public class UpdateAnnouncementRequest {
+
+  private FieldWrapper<String> title;
+  private FieldWrapper<String> content;
+  private FieldWrapper<String> imageUrl;
+}

--- a/src/main/java/org/mju_likelion/festival/announcement/service/AnnouncementService.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/service/AnnouncementService.java
@@ -1,6 +1,7 @@
 package org.mju_likelion.festival.announcement.service;
 
 import static org.mju_likelion.festival.common.exception.type.ErrorType.ADMIN_NOT_FOUND_ERROR;
+import static org.mju_likelion.festival.common.exception.type.ErrorType.ANNOUNCEMENT_NOT_FOUND_ERROR;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -10,7 +11,7 @@ import org.mju_likelion.festival.admin.domain.repository.AdminJpaRepository;
 import org.mju_likelion.festival.announcement.domain.Announcement;
 import org.mju_likelion.festival.announcement.domain.repository.AnnouncementJpaRepository;
 import org.mju_likelion.festival.announcement.dto.request.CreateAnnouncementRequest;
-import org.mju_likelion.festival.booth.domain.repository.BoothJpaRepository;
+import org.mju_likelion.festival.announcement.dto.request.UpdateAnnouncementRequest;
 import org.mju_likelion.festival.common.exception.NotFoundException;
 import org.mju_likelion.festival.image.domain.Image;
 import org.springframework.stereotype.Service;
@@ -21,7 +22,6 @@ public class AnnouncementService {
 
   private final AnnouncementJpaRepository announcementJpaRepository;
   private final AdminJpaRepository adminJpaRepository;
-  private final BoothJpaRepository boothJpaRepository;
 
   public void createAnnouncement(CreateAnnouncementRequest createAnnouncementRequest,
       UUID adminId) {
@@ -29,21 +29,51 @@ public class AnnouncementService {
     Admin admin = getExistingAdmin(adminId);
 
     Image image = Optional.ofNullable(createAnnouncementRequest.getImageUrl())
-        .map(Image::new)
-        .orElse(null);
+        .map(Image::new).orElse(null);
 
-    Announcement announcement = new Announcement(
-        createAnnouncementRequest.getTitle(),
-        createAnnouncementRequest.getContent(),
-        image,
-        admin
-    );
+    Announcement announcement = new Announcement(createAnnouncementRequest.getTitle(),
+        createAnnouncementRequest.getContent(), image, admin);
 
     announcementJpaRepository.save(announcement);
   }
 
-  public Admin getExistingAdmin(UUID adminId) {
+  public void updateAnnouncement(UUID announcementId,
+      UpdateAnnouncementRequest updateAnnouncementRequest, UUID adminId) {
+
+    Announcement announcement = getExistingAnnouncement(announcementId);
+
+    validateAdminExistence(adminId);
+
+    // title 은 null 을 허용하지 않는다.
+    updateAnnouncementRequest.getTitle()
+        .doIfPresentAndNotNull(announcement::updateTitle);
+
+    // content 는 null 을 허용하지 않는다.
+    updateAnnouncementRequest.getContent()
+        .doIfPresentAndNotNull(announcement::updateContent);
+
+    // imageUrl 은 null 을 허용한다.
+    updateAnnouncementRequest.getImageUrl().doIfPresent(imageUrl -> {
+      Image image = Optional.ofNullable(imageUrl).map(Image::new).orElse(null);
+      announcement.updateImage(image);
+    });
+
+    announcementJpaRepository.save(announcement);
+  }
+
+  private void validateAdminExistence(UUID adminId) {
+    if (!adminJpaRepository.existsById(adminId)) {
+      throw new NotFoundException(ADMIN_NOT_FOUND_ERROR);
+    }
+  }
+
+  private Admin getExistingAdmin(UUID adminId) {
     return adminJpaRepository.findById(adminId)
         .orElseThrow(() -> new NotFoundException(ADMIN_NOT_FOUND_ERROR));
+  }
+
+  private Announcement getExistingAnnouncement(UUID announcementId) {
+    return announcementJpaRepository.findById(announcementId)
+        .orElseThrow(() -> new NotFoundException(ANNOUNCEMENT_NOT_FOUND_ERROR));
   }
 }

--- a/src/main/java/org/mju_likelion/festival/announcement/util/deserializer/UpdateAnnouncementRequestDeserializer.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/util/deserializer/UpdateAnnouncementRequestDeserializer.java
@@ -1,0 +1,56 @@
+package org.mju_likelion.festival.announcement.util.deserializer;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.INVALID_REQUEST_BODY_ERROR;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.mju_likelion.festival.announcement.dto.request.UpdateAnnouncementRequest;
+import org.mju_likelion.festival.common.exception.BadRequestException;
+import org.mju_likelion.festival.common.util.field_wrapper.FieldWrapper;
+
+/**
+ * 공지사항 수정 요청 Deserializer
+ * <p>
+ * title, content, imageUrl을 역직렬화한다.
+ * <p>
+ * 클라이언트가 null 을 전송한 것인지 아니면 필드 자체가 없는 것인지 구분하기 위해 JsonNode 의 isNull() 메서드를 사용한다.
+ */
+public class UpdateAnnouncementRequestDeserializer extends
+    StdDeserializer<UpdateAnnouncementRequest> {
+
+  public UpdateAnnouncementRequestDeserializer() {
+    this(null);
+  }
+
+  public UpdateAnnouncementRequestDeserializer(Class<?> vc) {
+    super(vc);
+  }
+
+  @Override
+  public UpdateAnnouncementRequest deserialize(JsonParser jp, DeserializationContext ctxt) {
+
+    try {
+      JsonNode node = jp.getCodec().readTree(jp);
+      UpdateAnnouncementRequest request = new UpdateAnnouncementRequest();
+
+      request.setTitle(getStringFieldWrapper(node, "title"));
+      request.setContent(getStringFieldWrapper(node, "content"));
+      request.setImageUrl(getStringFieldWrapper(node, "imageUrl"));
+
+      return request;
+    } catch (Exception e) {
+      throw new BadRequestException(INVALID_REQUEST_BODY_ERROR);
+    }
+  }
+
+  private FieldWrapper<String> getStringFieldWrapper(JsonNode node, String fieldName) {
+    if (node.has(fieldName)) {
+      JsonNode fieldNode = node.get(fieldName);
+      return new FieldWrapper<>(true, fieldNode.isNull() ? null : fieldNode.asText());
+    } else {
+      return new FieldWrapper<>(false, null);
+    }
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/config/AuthenticationConfig.java
+++ b/src/main/java/org/mju_likelion/festival/common/config/AuthenticationConfig.java
@@ -47,7 +47,8 @@ public class AuthenticationConfig implements WebMvcConfigurer {
    */
   private void addStudentCouncilAuthenticationInterceptor(final InterceptorRegistry registry) {
     registry.addInterceptor(studentCouncilAuthenticationInterceptor)
-        .addPathPatterns("/announcements");
+        .addPathPatterns("/announcements")
+        .addPathPatterns("/announcements/{id}");
   }
 
   /**

--- a/src/main/java/org/mju_likelion/festival/common/util/field_wrapper/FieldWrapper.java
+++ b/src/main/java/org/mju_likelion/festival/common/util/field_wrapper/FieldWrapper.java
@@ -1,0 +1,49 @@
+package org.mju_likelion.festival.common.util.field_wrapper;
+
+import java.util.function.Consumer;
+
+/**
+ * 필드 래퍼
+ * <p>
+ * JSON 에서 필드가 존재하는지 여부와 값의 유무를 구분하기 위한 래퍼 클래스
+ */
+public class FieldWrapper<T> {
+
+  private final boolean present; // 필드가 존재하는지 여부
+  private final T value; // 필드 값
+
+  public FieldWrapper(boolean present, T value) {
+    this.present = present;
+    this.value = value;
+  }
+
+  public boolean isPresent() {
+    return present;
+  }
+
+  public T getValue() {
+    return value;
+  }
+
+  /**
+   * 값이 존재하고 null 이 아닐 때만 consumer 를 실행한다.
+   *
+   * @param consumer 실행할 consumer
+   */
+  public void doIfPresentAndNotNull(Consumer<T> consumer) {
+    if (isPresent() && value != null) {
+      consumer.accept(value);
+    }
+  }
+
+  /**
+   * 값이 존재할 때만 consumer 를 실행한다.
+   *
+   * @param consumer 실행할 consumer
+   */
+  public void doIfPresent(Consumer<T> consumer) {
+    if (isPresent()) {
+      consumer.accept(value);
+    }
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/util/string/StringUtil.java
+++ b/src/main/java/org/mju_likelion/festival/common/util/string/StringUtil.java
@@ -5,7 +5,7 @@ package org.mju_likelion.festival.common.util.string;
  */
 public class StringUtil {
 
-  public static boolean isEmptyOrLargerThan(String str, int length) {
-    return str.isEmpty() || str.length() > length;
+  public static boolean isBlankOrLargerThan(String str, int length) {
+    return str.isBlank() || str.length() > length;
   }
 }

--- a/src/main/java/org/mju_likelion/festival/image/domain/Image.java
+++ b/src/main/java/org/mju_likelion/festival/image/domain/Image.java
@@ -26,7 +26,7 @@ public class Image extends BaseEntity {
   }
 
   public void validateUrl(String url) {
-    if (StringUtil.isEmptyOrLargerThan(url, IMAGE_URL_LENGTH)) {
+    if (StringUtil.isBlankOrLargerThan(url, IMAGE_URL_LENGTH)) {
       throw new BadRequestException(INVALID_IMAGE_URL_LENGTH_ERROR);
     }
   }


### PR DESCRIPTION
## Description
공지사항 수정 API 개발
## Changes
### PATCH 에서 사용할 Field Wrapper
- [x] FieldWrapper
### FieldWrapper를 사용한 요청 DTO Deserializer
- [x] UpdateAnnouncementRequestDeserializer
### Service
- [x] AnnouncementService
### Controller
- [x] AnnouncementController
### 학생회만 가능하도록
- [x] AuthenticationConfig

### API
| URL                     | method | Usage                   | Authorization Needed |
| ------------------ | ---------| -------------------- | ------------------------ |
|         /announcements                   |    PATCH           |                공지사항 수정               |                        O            |

## Additional context
부분 수정이므로 PATCH 를 사용하였음

이슈 발생
Request Body 로는 title, content, imageUrl 을 받아야 함
하지만, FrontEnd 에서 의도적으로 null 을 준 것인지, 해당 필드를 주지 않아서 null 이 된 것인지 구분해야 했음.
왜냐하면, Image 는 Nullable 이기 때문 -> null 이 들어오면 null로 업데이트해야 함

FieldWrapper 와 JSON 역직렬화를 커스텀해 해결
FieldWrapper 의 isPresent 를 통해  Request Body JSON에서 해당 필드가 있었는지도 파악 가능

Closes #74 