### PR TITLE
Feature/#82 공지사항 조회 시 생성 시간도 반환하도록 변경

### DIFF
--- a/src/main/java/org/mju_likelion/festival/announcement/domain/AnnouncementDetail.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/AnnouncementDetail.java
@@ -1,5 +1,6 @@
 package org.mju_likelion.festival.announcement.domain;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,5 +15,6 @@ public class AnnouncementDetail {
   private final UUID id;
   private final String title;
   private final String content;
+  private final LocalDateTime createdAt;
   private final String imageUrl;
 }

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/SimpleAnnouncement.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/SimpleAnnouncement.java
@@ -1,5 +1,6 @@
 package org.mju_likelion.festival.announcement.domain;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,4 +12,5 @@ public class SimpleAnnouncement {
   private final UUID id;
   private final String title;
   private final String content;
+  private final LocalDateTime createdAt;
 }

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementQueryRepository.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementQueryRepository.java
@@ -31,7 +31,8 @@ public class AnnouncementQueryRepository {
       return new SimpleAnnouncement(
           uuid,
           rs.getString("title"),
-          rs.getString("content")
+          rs.getString("content"),
+          rs.getTimestamp("createdAt").toLocalDateTime()
       );
     };
   }
@@ -44,6 +45,7 @@ public class AnnouncementQueryRepository {
           uuid,
           rs.getString("title"),
           rs.getString("content"),
+          rs.getTimestamp("createdAt").toLocalDateTime(),
           rs.getString("imageUrl")
       );
     };
@@ -60,10 +62,11 @@ public class AnnouncementQueryRepository {
   public List<SimpleAnnouncement> findOrderedSimpleAnnouncementsWithPagenation(Direction direction,
       final int page,
       final int size) {
-    String sql = "SELECT HEX(a.id) AS announcementId, a.title AS title, a.content AS content "
-        + "FROM announcement a "
-        + "ORDER BY a.created_at " + direction.toString() + " "
-        + "LIMIT :limit OFFSET :offset";
+    String sql =
+        "SELECT HEX(a.id) AS announcementId, a.title AS title, a.content AS content, a.created_at AS createdAt "
+            + "FROM announcement a "
+            + "ORDER BY a.created_at " + direction.toString() + " "
+            + "LIMIT :limit OFFSET :offset";
 
     MapSqlParameterSource params = new MapSqlParameterSource()
         .addValue("limit", size)
@@ -79,7 +82,8 @@ public class AnnouncementQueryRepository {
    */
   public Optional<AnnouncementDetail> findAnnouncementById(final UUID id) {
     String sql =
-        "SELECT HEX(a.id) AS announcementId, a.title AS title, a.content AS content,  i.url AS imageUrl "
+        "SELECT HEX(a.id) AS announcementId, a.title AS title, a.content AS content, "
+            + "a.created_at AS createdAt, i.url AS imageUrl "
             + "FROM announcement a "
             + "LEFT JOIN image i ON a.image_id = i.id "
             + "WHERE a.id = UNHEX(:id)";

--- a/src/main/java/org/mju_likelion/festival/announcement/dto/response/AnnouncementDetailResponse.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/dto/response/AnnouncementDetailResponse.java
@@ -1,6 +1,7 @@
 package org.mju_likelion.festival.announcement.dto.response;
 
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -17,6 +18,7 @@ public class AnnouncementDetailResponse {
   private final UUID id;
   private final String title;
   private final String content;
+  private final LocalDateTime createdAt;
   private final String imageUrl;
 
   public static AnnouncementDetailResponse from(final AnnouncementDetail announcementDetail) {
@@ -25,6 +27,7 @@ public class AnnouncementDetailResponse {
         announcementDetail.getId(),
         announcementDetail.getTitle(),
         announcementDetail.getContent(),
+        announcementDetail.getCreatedAt(),
         announcementDetail.getImageUrl()
     );
   }

--- a/src/main/java/org/mju_likelion/festival/announcement/dto/response/SimpleAnnouncementsResponse.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/dto/response/SimpleAnnouncementsResponse.java
@@ -13,7 +13,7 @@ public class SimpleAnnouncementsResponse {
   private final List<SimpleAnnouncement> simpleAnnouncements;
   private final int totalPage;
 
-  public static SimpleAnnouncementsResponse from(
+  public static SimpleAnnouncementsResponse of(
       List<SimpleAnnouncement> simpleAnnouncements,
       int totalPage) {
 

--- a/src/main/java/org/mju_likelion/festival/announcement/service/AnnouncementQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/service/AnnouncementQueryService.java
@@ -31,7 +31,7 @@ public class AnnouncementQueryService {
     List<SimpleAnnouncement> simpleAnnouncements = announcementQueryRepository
         .findOrderedSimpleAnnouncementsWithPagenation(sort, page, size);
 
-    return SimpleAnnouncementsResponse.from(simpleAnnouncements, totalPage);
+    return SimpleAnnouncementsResponse.of(simpleAnnouncements, totalPage);
   }
 
   public AnnouncementDetailResponse getAnnouncement(UUID id) {

--- a/src/test/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementQueryRepositoryTest.java
+++ b/src/test/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementQueryRepositoryTest.java
@@ -3,6 +3,7 @@ package org.mju_likelion.festival.announcement.domain.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
@@ -58,8 +59,7 @@ public class AnnouncementQueryRepositoryTest {
       assertAll(
           () -> {
             assertThat(pageContent).isSortedAccordingTo(
-                (a, b) -> announcementJpaRepository.findById(a.getId()).get().getCreatedAt()
-                    .compareTo(announcementJpaRepository.findById(b.getId()).get().getCreatedAt()));
+                Comparator.comparing(SimpleAnnouncement::getCreatedAt));
 
             assertThat(pageContent)
                 .hasSize(expectedSize)
@@ -87,8 +87,8 @@ public class AnnouncementQueryRepositoryTest {
       assertAll(
           () -> {
             assertThat(pageContent).isSortedAccordingTo(
-                (a, b) -> announcementJpaRepository.findById(b.getId()).get().getCreatedAt()
-                    .compareTo(announcementJpaRepository.findById(a.getId()).get().getCreatedAt()));
+                (a, b) -> b.getCreatedAt()
+                    .compareTo(a.getCreatedAt()));
 
             assertThat(pageContent)
                 .hasSize(expectedSize)


### PR DESCRIPTION
## Description

## Changes
### Domain
- [x] SimpleAnnouncement
- [x] AnnouncementDetail
### DTO
- [x] AnnouncementDetailResponse
### Repository
- [x] AnnouncementQueryRepository

## Additional context
Closes #82 