### PR TITLE
Feature/#89 Entity 컬럼 길이 필드에 @Transient 추가

### DIFF
--- a/src/main/java/org/mju_likelion/festival/admin/domain/Admin.java
+++ b/src/main/java/org/mju_likelion/festival/admin/domain/Admin.java
@@ -7,6 +7,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Transient;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -24,9 +25,13 @@ import org.mju_likelion.festival.lost_item.domain.LostItem;
 @Entity(name = "admin")
 public class Admin extends BaseEntity {
 
+  @Transient
   private final int NAME_LENGTH = 50;
+  @Transient
   private final int ID_LENGTH = 50;
+  @Transient
   private final int PASSWORD_LENGTH = 100;
+  @Transient
   private final int ROLE_LENGTH = 20;
 
   @Column(nullable = false, unique = true, length = NAME_LENGTH)

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/Announcement.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/Announcement.java
@@ -10,6 +10,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Transient;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.mju_likelion.festival.admin.domain.Admin;
@@ -23,7 +24,9 @@ import org.mju_likelion.festival.image.domain.Image;
 @Entity(name = "announcement")
 public class Announcement extends BaseEntity {
 
+  @Transient
   private final int TITLE_LENGTH = 50;
+  @Transient
   private final int CONTENT_LENGTH = 100;
 
   @Column(nullable = false, length = TITLE_LENGTH)

--- a/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Transient;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,8 +25,11 @@ import org.mju_likelion.festival.image.domain.Image;
 @Entity(name = "booth")
 public class Booth extends BaseEntity {
 
+  @Transient
   private final int NAME_LENGTH = 100;
+  @Transient
   private final int DESCRIPTION_LENGTH = 4000;
+  @Transient
   private final int LOCATION_LENGTH = 100;
 
   @OneToOne(optional = false, fetch = FetchType.LAZY)

--- a/src/main/java/org/mju_likelion/festival/image/domain/Image.java
+++ b/src/main/java/org/mju_likelion/festival/image/domain/Image.java
@@ -4,6 +4,7 @@ import static org.mju_likelion.festival.common.exception.type.ErrorType.INVALID_
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Transient;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,7 @@ import org.mju_likelion.festival.common.util.string.StringUtil;
 @Entity(name = "image")
 public class Image extends BaseEntity {
 
+  @Transient
   private final int URL_LENGTH = 256;
 
   @Column(nullable = false, length = URL_LENGTH)

--- a/src/main/java/org/mju_likelion/festival/lost_item/domain/LostItem.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/domain/LostItem.java
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Transient;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,8 +23,11 @@ import org.mju_likelion.festival.image.domain.Image;
 @Entity(name = "lost_item")
 public class LostItem extends BaseEntity {
 
+  @Transient
   private final int TITLE_LENGTH = 70;
+  @Transient
   private final int CONTENT_LENGTH = 100;
+  @Transient
   private final int OWNER_INFO_LENGTH = 150;
 
   @ManyToOne(optional = false, fetch = FetchType.LAZY)

--- a/src/main/java/org/mju_likelion/festival/term/domain/Term.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/Term.java
@@ -2,6 +2,7 @@ package org.mju_likelion.festival.term.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Transient;
 import java.util.Objects;
 import lombok.Getter;
 import org.mju_likelion.festival.common.domain.BaseEntity;
@@ -10,7 +11,9 @@ import org.mju_likelion.festival.common.domain.BaseEntity;
 @Entity(name = "term")
 public class Term extends BaseEntity {
 
+  @Transient
   private final int TITLE_LENGTH = 100;
+  @Transient
   private final int CONTENT_LENGTH = 4000;
 
   @Column(nullable = false, length = TITLE_LENGTH)

--- a/src/main/java/org/mju_likelion/festival/user/domain/User.java
+++ b/src/main/java/org/mju_likelion/festival/user/domain/User.java
@@ -3,6 +3,7 @@ package org.mju_likelion.festival.user.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Transient;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -18,6 +19,7 @@ import org.mju_likelion.festival.term.domain.TermUsers;
 @Entity(name = "user")
 public class User extends BaseEntity {
 
+  @Transient
   private final int STUDENT_ID_LENGTH = 8;
 
   @Column(name = "student_id", nullable = false, unique = true, length = STUDENT_ID_LENGTH)


### PR DESCRIPTION
## Description
Entity 컬럼 길이 필드에 @Transient 추가

컬럼으로 생성되게 하지 않게 하기 위함
## Changes
### @Transient 추가
- [x] Admin
- [x] Announcement
- [x] Booth
- [x] Image
- [x] LostItem
- [x] Term
- [x] User
## Additional context
Closes #89 