### PR TITLE
Feature/#88 분실물 전체 조회 API 개발

### DIFF
--- a/src/main/java/org/mju_likelion/festival/lost_item/controller/LostItemController.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/controller/LostItemController.java
@@ -1,0 +1,27 @@
+package org.mju_likelion.festival.lost_item.controller;
+
+import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.lost_item.dto.response.SimpleLostItemsResponse;
+import org.mju_likelion.festival.lost_item.service.LostItemQueryService;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/lost-items")
+public class LostItemController {
+
+  private final LostItemQueryService lostItemQueryService;
+
+  @GetMapping
+  public ResponseEntity<SimpleLostItemsResponse> getLostItems(@RequestParam String sort,
+      @RequestParam int page, @RequestParam int size) {
+
+    return ResponseEntity.ok(
+        lostItemQueryService.getLostItems(Direction.fromString(sort), page, size));
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/lost_item/domain/LostItem.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/domain/LostItem.java
@@ -40,7 +40,7 @@ public class LostItem extends BaseEntity {
   @Column(nullable = false, length = CONTENT_LENGTH)
   private String content;
 
-  @Column(nullable = false, length = OWNER_INFO_LENGTH)
+  @Column(length = OWNER_INFO_LENGTH)
   private String retrieverInfo;
 
   @OneToOne(optional = false, fetch = FetchType.LAZY, cascade = CascadeType.ALL)

--- a/src/main/java/org/mju_likelion/festival/lost_item/domain/SimpleLostItem.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/domain/SimpleLostItem.java
@@ -1,0 +1,17 @@
+package org.mju_likelion.festival.lost_item.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SimpleLostItem {
+
+  private final UUID id;
+  private final String title;
+  private final String content;
+  private final String imageUrl;
+  private final LocalDateTime createdAt;
+}

--- a/src/main/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemQueryRepository.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemQueryRepository.java
@@ -1,0 +1,76 @@
+package org.mju_likelion.festival.lost_item.domain.repository;
+
+import static org.mju_likelion.festival.common.util.uuid.UUIDUtil.hexToUUID;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.mju_likelion.festival.lost_item.domain.SimpleLostItem;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LostItemQueryRepository {
+
+  private final RowMapper<SimpleLostItem> simpleLostItemRowMapper = simpleLostItemRowMapper();
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  private RowMapper<SimpleLostItem> simpleLostItemRowMapper() {
+    return (rs, rowNum) -> {
+      String hexId = rs.getString("lostItemId");
+      UUID uuid = hexToUUID(hexId);
+      return new SimpleLostItem(
+          uuid,
+          rs.getString("title"),
+          rs.getString("content"),
+          rs.getString("imageUrl"),
+          rs.getTimestamp("createdAt").toLocalDateTime()
+      );
+    };
+  }
+
+  /**
+   * 페이지네이션을 적용하여 분실물 간단 정보 List 조회.
+   *
+   * @param direction 정렬
+   * @param page      페이지
+   * @param size      크기
+   * @return 분실물 간단 정보 List
+   */
+  public List<SimpleLostItem> findOrderedSimpleLostItemsWithPagenation(final Direction direction,
+      final int page,
+      final int size) {
+    String sql =
+        "SELECT HEX(li.id) AS lostItemId, li.title AS title, li.content AS content, "
+            + "i.url AS imageUrl, li.created_at AS createdAt "
+            + "FROM lost_item li "
+            + "LEFT JOIN image i ON li.image_id = i.id "
+            + "ORDER BY li.created_at " + direction.toString() + " "
+            + "LIMIT :limit OFFSET :offset";
+
+    MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("limit", size)
+        .addValue("offset", page * size);
+
+    return jdbcTemplate.query(sql, params, simpleLostItemRowMapper);
+  }
+
+  /**
+   * 총 페이지 수 조회.
+   *
+   * @param size 크기
+   * @return 총 페이지 수
+   */
+  public int findTotalPage(final int size) {
+    String sql = "SELECT CEIL(COUNT(*) / :size) FROM lost_item";
+
+    MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("size", size);
+
+    return jdbcTemplate.queryForObject(sql, params, Integer.class);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/lost_item/dto/response/SimpleLostItemsResponse.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/dto/response/SimpleLostItemsResponse.java
@@ -1,0 +1,25 @@
+package org.mju_likelion.festival.lost_item.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.mju_likelion.festival.lost_item.domain.SimpleLostItem;
+
+/**
+ * 분실물 간단 정보 응답 DTO.
+ */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SimpleLostItemsResponse {
+
+  private final List<SimpleLostItem> simpleLostItems;
+  private final int totalPage;
+
+  public static SimpleLostItemsResponse of(
+      final List<SimpleLostItem> simpleLostItem,
+      final int totalPage) {
+
+    return new SimpleLostItemsResponse(simpleLostItem, totalPage);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/lost_item/service/LostItemQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/service/LostItemQueryService.java
@@ -1,0 +1,40 @@
+package org.mju_likelion.festival.lost_item.service;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.PAGE_OUT_OF_BOUND_ERROR;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.common.exception.NotFoundException;
+import org.mju_likelion.festival.lost_item.domain.SimpleLostItem;
+import org.mju_likelion.festival.lost_item.domain.repository.LostItemQueryRepository;
+import org.mju_likelion.festival.lost_item.dto.response.SimpleLostItemsResponse;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class LostItemQueryService {
+
+  private final LostItemQueryRepository lostItemQueryRepository;
+
+
+  public SimpleLostItemsResponse getLostItems(final Direction sort, final int page,
+      final int size) {
+
+    int totalPage = lostItemQueryRepository.findTotalPage(size);
+
+    validatePage(page, totalPage);
+
+    List<SimpleLostItem> simpleLostItems = lostItemQueryRepository.findOrderedSimpleLostItemsWithPagenation(
+        sort, page,
+        size);
+
+    return SimpleLostItemsResponse.of(simpleLostItems, totalPage);
+  }
+
+  private void validatePage(int page, int totalPage) {
+    if (page >= totalPage) {
+      throw new NotFoundException(PAGE_OUT_OF_BOUND_ERROR);
+    }
+  }
+}

--- a/src/test/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemQueryRepositoryTest.java
+++ b/src/test/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemQueryRepositoryTest.java
@@ -1,0 +1,105 @@
+package org.mju_likelion.festival.lost_item.domain.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.IntStream;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mju_likelion.festival.common.annotation.ApplicationTest;
+import org.mju_likelion.festival.lost_item.domain.SimpleLostItem;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("LostItemQueryRepository")
+@ApplicationTest
+@Transactional(readOnly = true)
+public class LostItemQueryRepositoryTest {
+
+  @Autowired
+  private LostItemQueryRepository lostItemQueryRepository;
+
+  @Autowired
+  private DataSource dataSource;
+
+  @Autowired
+  private LostItemJpaRepository lostItemJpaRepository;
+
+  private int totalLostItemNum;
+
+  @BeforeEach
+  void setUp() {
+    lostItemQueryRepository = new LostItemQueryRepository(
+        new NamedParameterJdbcTemplate(dataSource));
+    totalLostItemNum = (int) lostItemJpaRepository.count();
+  }
+
+  @DisplayName("분실물 간단 정보 List 조회 - 페이지네이션 ( 생성 시간 오름차순 )")
+  @Test
+  void testFindOrderedSimpleLostItemsWithPagination() {
+    // given
+    int pageSize = 5;
+    int totalPages = calculateTotalPages(totalLostItemNum, pageSize);
+
+    // when & then
+    IntStream.range(0, totalPages).forEach(page -> {
+      List<SimpleLostItem> pageContent = lostItemQueryRepository.findOrderedSimpleLostItemsWithPagenation(
+          Direction.ASC, page, pageSize);
+
+      int expectedSize = calculateExpectedSize(page, pageSize, totalLostItemNum);
+
+      assertAll(
+          () -> {
+            assertThat(pageContent).hasSize(expectedSize);
+            assertThat(pageContent).isSortedAccordingTo(
+                Comparator.comparing(SimpleLostItem::getCreatedAt));
+          }
+      );
+    });
+  }
+
+  @DisplayName("분실물 간단 정보 List 조회 - 페이지네이션 ( 생성 시간 내림차순 )")
+  @Test
+  void testFindOrderedSimpleLostItemsWithPaginationDesc() {
+    // given
+    int pageSize = 5;
+    int totalPages = calculateTotalPages(totalLostItemNum, pageSize);
+
+    // when & then
+    IntStream.range(0, totalPages).forEach(page -> {
+      List<SimpleLostItem> pageContent = lostItemQueryRepository.findOrderedSimpleLostItemsWithPagenation(
+          Direction.DESC, page, pageSize);
+
+      int expectedSize = calculateExpectedSize(page, pageSize, totalLostItemNum);
+
+      assertAll(
+          () -> {
+            assertThat(pageContent).hasSize(expectedSize);
+            assertThat(pageContent).isSortedAccordingTo(
+                Comparator.comparing(SimpleLostItem::getCreatedAt).reversed());
+          }
+      );
+    });
+  }
+
+  private int calculateTotalPages(int totalItems, int pageSize) {
+    return (totalItems + pageSize - 1) / pageSize;
+  }
+
+  private int calculateExpectedSize(int page, int pageSize, int totalBoothNum) {
+    if (isLastPage(page, totalBoothNum, pageSize)) {
+      return totalBoothNum % pageSize == 0 ? pageSize : totalBoothNum % pageSize;
+    }
+    return pageSize;
+  }
+
+  private boolean isLastPage(int page, int totalBoothNum, int pageSize) {
+    return page == calculateTotalPages(totalBoothNum, pageSize) - 1;
+  }
+}


### PR DESCRIPTION
## Description
분실물 전체 조회 API 개발

상세 조회 API 는 구현하지 않을 예정
## Changes
### 간단 분실물 정보 domain
- [x] SimpleLostItem
### QueryRepository 추가
- [x] LostItemQueryRepository
### QueryService
- [x] LostItemQueryService
### Controller 
- [x] LostItemController
### 테스트 코드
- [x] LostItemQueryRepositoryTest

### API
| URL                     | method | Usage                   | Authorization Needed |
| ------------------ | ---------| -------------------- | ------------------------ |
|         /lost-items                   |       GET        |              분실물 전체 조회                 |              X                      |

## Additional context
Closes #88 