### PR TITLE
Feature/#92 페이지네이션 시 음수 페이지 예외처리 추가

### DIFF
--- a/src/main/java/org/mju_likelion/festival/announcement/controller/AnnouncementController.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/controller/AnnouncementController.java
@@ -9,6 +9,8 @@ import org.mju_likelion.festival.announcement.dto.response.AnnouncementDetailRes
 import org.mju_likelion.festival.announcement.dto.response.SimpleAnnouncementsResponse;
 import org.mju_likelion.festival.announcement.service.AnnouncementQueryService;
 import org.mju_likelion.festival.announcement.service.AnnouncementService;
+import org.mju_likelion.festival.common.annotaion.page_number.PageNumber;
+import org.mju_likelion.festival.common.annotaion.page_size.PageSize;
 import org.mju_likelion.festival.common.authentication.AuthenticationPrincipal;
 import org.mju_likelion.festival.common.enums.SortOrder;
 import org.springframework.http.ResponseEntity;
@@ -33,7 +35,8 @@ public class AnnouncementController {
   @GetMapping
   public ResponseEntity<SimpleAnnouncementsResponse> getAnnouncements(
       @RequestParam String sort,
-      @RequestParam int page, @RequestParam int size) {
+      @RequestParam @PageNumber int page,
+      @RequestParam @PageSize int size) {
 
     return ResponseEntity.ok(
         announcementQueryService.getAnnouncements(SortOrder.fromString(sort), page, size));

--- a/src/main/java/org/mju_likelion/festival/announcement/controller/AnnouncementController.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/controller/AnnouncementController.java
@@ -10,7 +10,7 @@ import org.mju_likelion.festival.announcement.dto.response.SimpleAnnouncementsRe
 import org.mju_likelion.festival.announcement.service.AnnouncementQueryService;
 import org.mju_likelion.festival.announcement.service.AnnouncementService;
 import org.mju_likelion.festival.common.authentication.AuthenticationPrincipal;
-import org.springframework.data.domain.Sort.Direction;
+import org.mju_likelion.festival.common.enums.SortOrder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,7 +36,7 @@ public class AnnouncementController {
       @RequestParam int page, @RequestParam int size) {
 
     return ResponseEntity.ok(
-        announcementQueryService.getAnnouncements(Direction.fromString(sort), page, size));
+        announcementQueryService.getAnnouncements(SortOrder.fromString(sort), page, size));
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementQueryRepository.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementQueryRepository.java
@@ -9,8 +9,8 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.mju_likelion.festival.announcement.domain.AnnouncementDetail;
 import org.mju_likelion.festival.announcement.domain.SimpleAnnouncement;
+import org.mju_likelion.festival.common.enums.SortOrder;
 import org.springframework.dao.support.DataAccessUtils;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -54,18 +54,18 @@ public class AnnouncementQueryRepository {
   /**
    * 페이지네이션을 적용하여 공지사항 간단 정보 List 조회.
    *
-   * @param direction 정렬
+   * @param sortOrder 정렬
    * @param page      페이지
    * @param size      크기
    * @return 공지사항 간단 정보 List
    */
-  public List<SimpleAnnouncement> findOrderedSimpleAnnouncementsWithPagenation(Direction direction,
+  public List<SimpleAnnouncement> findOrderedSimpleAnnouncementsWithPagenation(SortOrder sortOrder,
       final int page,
       final int size) {
     String sql =
         "SELECT HEX(a.id) AS announcementId, a.title AS title, a.content AS content, a.created_at AS createdAt "
             + "FROM announcement a "
-            + "ORDER BY a.created_at " + direction.toString() + " "
+            + "ORDER BY a.created_at " + sortOrder.toString() + " "
             + "LIMIT :limit OFFSET :offset";
 
     MapSqlParameterSource params = new MapSqlParameterSource()

--- a/src/main/java/org/mju_likelion/festival/announcement/service/AnnouncementQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/service/AnnouncementQueryService.java
@@ -10,8 +10,8 @@ import org.mju_likelion.festival.announcement.domain.SimpleAnnouncement;
 import org.mju_likelion.festival.announcement.domain.repository.AnnouncementQueryRepository;
 import org.mju_likelion.festival.announcement.dto.response.AnnouncementDetailResponse;
 import org.mju_likelion.festival.announcement.dto.response.SimpleAnnouncementsResponse;
+import org.mju_likelion.festival.common.enums.SortOrder;
 import org.mju_likelion.festival.common.exception.NotFoundException;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,7 +22,7 @@ public class AnnouncementQueryService {
 
   private final AnnouncementQueryRepository announcementQueryRepository;
 
-  public SimpleAnnouncementsResponse getAnnouncements(Direction sort, int page, int size) {
+  public SimpleAnnouncementsResponse getAnnouncements(SortOrder sort, int page, int size) {
 
     int totalPage = announcementQueryRepository.getTotalPage(size);
 

--- a/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
+++ b/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
@@ -9,6 +9,8 @@ import org.mju_likelion.festival.booth.dto.response.BoothQrResponse;
 import org.mju_likelion.festival.booth.dto.response.SimpleBoothsResponse;
 import org.mju_likelion.festival.booth.service.BoothQueryService;
 import org.mju_likelion.festival.booth.service.BoothService;
+import org.mju_likelion.festival.common.annotaion.page_number.PageNumber;
+import org.mju_likelion.festival.common.annotaion.page_size.PageSize;
 import org.mju_likelion.festival.common.authentication.AuthenticationPrincipal;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,8 +32,8 @@ public class BoothController {
 
   @GetMapping
   public ResponseEntity<SimpleBoothsResponse> getBooths(
-      @RequestParam final int page,
-      @RequestParam final int size) {
+      @RequestParam @PageNumber final int page,
+      @RequestParam @PageSize final int size) {
     return ResponseEntity.ok(boothQueryService.getBooths(page, size));
   }
 

--- a/src/main/java/org/mju_likelion/festival/common/annotaion/page_number/PageNumber.java
+++ b/src/main/java/org/mju_likelion/festival/common/annotaion/page_number/PageNumber.java
@@ -1,0 +1,20 @@
+package org.mju_likelion.festival.common.annotaion.page_number;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = PageNumberValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PageNumber {
+
+  String message() default "페이지 번호는 0 보다 크거나 같아야 합니다.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/mju_likelion/festival/common/annotaion/page_number/PageNumberValidator.java
+++ b/src/main/java/org/mju_likelion/festival/common/annotaion/page_number/PageNumberValidator.java
@@ -1,0 +1,19 @@
+package org.mju_likelion.festival.common.annotaion.page_number;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PageNumberValidator implements ConstraintValidator<PageNumber, Integer> {
+
+  @Override
+  public void initialize(PageNumber constraintAnnotation) {
+  }
+
+  @Override
+  public boolean isValid(Integer value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return false;
+    }
+    return value >= 0;
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/annotaion/page_size/PageSize.java
+++ b/src/main/java/org/mju_likelion/festival/common/annotaion/page_size/PageSize.java
@@ -1,0 +1,20 @@
+package org.mju_likelion.festival.common.annotaion.page_size;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = PageSizeValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PageSize {
+
+  String message() default "페이지 크기는 1보다 크거나 같아야 합니다.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/mju_likelion/festival/common/annotaion/page_size/PageSizeValidator.java
+++ b/src/main/java/org/mju_likelion/festival/common/annotaion/page_size/PageSizeValidator.java
@@ -1,0 +1,19 @@
+package org.mju_likelion.festival.common.annotaion.page_size;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PageSizeValidator implements ConstraintValidator<PageSize, Integer> {
+
+  @Override
+  public void initialize(PageSize constraintAnnotation) {
+  }
+
+  @Override
+  public boolean isValid(Integer value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return false;
+    }
+    return value >= 1;
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/enums/SortOrder.java
+++ b/src/main/java/org/mju_likelion/festival/common/enums/SortOrder.java
@@ -1,0 +1,24 @@
+package org.mju_likelion.festival.common.enums;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.INVALID_SORT_ORDER_ERROR;
+
+import lombok.Getter;
+import org.mju_likelion.festival.common.exception.BadRequestException;
+
+/**
+ * 정렬 순서를 나타내는 Enum
+ */
+@Getter
+public enum SortOrder {
+
+  ASC,
+  DESC;
+
+  public static SortOrder fromString(String value) {
+    try {
+      return SortOrder.valueOf(value.toUpperCase());
+    } catch (Exception e) {
+      throw new BadRequestException(INVALID_SORT_ORDER_ERROR);
+    }
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/exception/controller/ExceptionController.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/controller/ExceptionController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
@@ -38,6 +39,22 @@ public class ExceptionController {
 
     BadRequestException badRequestException = new BadRequestException(
         ErrorType.INVALID_REQUEST_BODY_ERROR, message);
+
+    writeLog(badRequestException);
+    return ResponseEntity.badRequest().body(ErrorResponse.res(badRequestException));
+  }
+
+  // HandlerMethodValidationException 예외를 처리하는 핸들러(요청 시 검증을 통과하지 못한 경우)
+  @ExceptionHandler(HandlerMethodValidationException.class)
+  public ResponseEntity<ErrorResponse> handlerMethodValidationExceptionHandler(
+      final HandlerMethodValidationException e) {
+
+    String failedParameter = e.getValueResults().get(0).getMethodParameter().getParameterName()
+        + " : "
+        + e.getDetailMessageArguments()[0].toString();
+
+    BadRequestException badRequestException = new BadRequestException(
+        ErrorType.INVALID_REQUEST_PARAMETER_ERROR, failedParameter);
 
     writeLog(badRequestException);
     return ResponseEntity.badRequest().body(ErrorResponse.res(badRequestException));

--- a/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
@@ -23,6 +23,7 @@ public enum ErrorType {
   INVALID_BOOTH_NAME_LENGTH_ERROR(40013, "올바르지 않은 부스 이름 길이입니다."),
   INVALID_BOOTH_DESCRIPTION_LENGTH_ERROR(40014, "올바르지 않은 부스 설명 길이입니다."),
   INVALID_BOOTH_LOCATION_LENGTH_ERROR(40015, "올바르지 않은 부스 위치 길이입니다."),
+  INVALID_SORT_ORDER_ERROR(40016, "올바르지 않은 정렬 순서입니다."),
 
   INVALID_CREDENTIALS_ERROR(40100, "아이디나 비밀번호가 일치하지 않습니다."),
   NOT_AUTHENTICATED_ERROR(40101, "인증되지 않았습니다."),

--- a/src/main/java/org/mju_likelion/festival/lost_item/controller/LostItemController.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/controller/LostItemController.java
@@ -21,7 +21,8 @@ public class LostItemController {
 
   @GetMapping
   public ResponseEntity<SimpleLostItemsResponse> getLostItems(@RequestParam String sort,
-      @RequestParam int page, @RequestParam int size) {
+      @RequestParam @PageNumber int page,
+      @RequestParam @PageSize int size) {
 
     return ResponseEntity.ok(
         lostItemQueryService.getLostItems(SortOrder.fromString(sort), page, size));

--- a/src/main/java/org/mju_likelion/festival/lost_item/controller/LostItemController.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/controller/LostItemController.java
@@ -1,9 +1,11 @@
 package org.mju_likelion.festival.lost_item.controller;
 
 import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.common.annotaion.page_number.PageNumber;
+import org.mju_likelion.festival.common.annotaion.page_size.PageSize;
+import org.mju_likelion.festival.common.enums.SortOrder;
 import org.mju_likelion.festival.lost_item.dto.response.SimpleLostItemsResponse;
 import org.mju_likelion.festival.lost_item.service.LostItemQueryService;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +24,6 @@ public class LostItemController {
       @RequestParam int page, @RequestParam int size) {
 
     return ResponseEntity.ok(
-        lostItemQueryService.getLostItems(Direction.fromString(sort), page, size));
+        lostItemQueryService.getLostItems(SortOrder.fromString(sort), page, size));
   }
 }

--- a/src/main/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemQueryRepository.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemQueryRepository.java
@@ -5,8 +5,8 @@ import static org.mju_likelion.festival.common.util.uuid.UUIDUtil.hexToUUID;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.mju_likelion.festival.common.enums.SortOrder;
 import org.mju_likelion.festival.lost_item.domain.SimpleLostItem;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -36,12 +36,12 @@ public class LostItemQueryRepository {
   /**
    * 페이지네이션을 적용하여 분실물 간단 정보 List 조회.
    *
-   * @param direction 정렬
+   * @param sortOrder 정렬
    * @param page      페이지
    * @param size      크기
    * @return 분실물 간단 정보 List
    */
-  public List<SimpleLostItem> findOrderedSimpleLostItemsWithPagenation(final Direction direction,
+  public List<SimpleLostItem> findOrderedSimpleLostItemsWithPagenation(final SortOrder sortOrder,
       final int page,
       final int size) {
     String sql =
@@ -49,7 +49,7 @@ public class LostItemQueryRepository {
             + "i.url AS imageUrl, li.created_at AS createdAt "
             + "FROM lost_item li "
             + "LEFT JOIN image i ON li.image_id = i.id "
-            + "ORDER BY li.created_at " + direction.toString() + " "
+            + "ORDER BY li.created_at " + sortOrder.toString() + " "
             + "LIMIT :limit OFFSET :offset";
 
     MapSqlParameterSource params = new MapSqlParameterSource()

--- a/src/main/java/org/mju_likelion/festival/lost_item/service/LostItemQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/service/LostItemQueryService.java
@@ -4,11 +4,11 @@ import static org.mju_likelion.festival.common.exception.type.ErrorType.PAGE_OUT
 
 import java.util.List;
 import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.common.enums.SortOrder;
 import org.mju_likelion.festival.common.exception.NotFoundException;
 import org.mju_likelion.festival.lost_item.domain.SimpleLostItem;
 import org.mju_likelion.festival.lost_item.domain.repository.LostItemQueryRepository;
 import org.mju_likelion.festival.lost_item.dto.response.SimpleLostItemsResponse;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,7 +18,7 @@ public class LostItemQueryService {
   private final LostItemQueryRepository lostItemQueryRepository;
 
 
-  public SimpleLostItemsResponse getLostItems(final Direction sort, final int page,
+  public SimpleLostItemsResponse getLostItems(final SortOrder sort, final int page,
       final int size) {
 
     int totalPage = lostItemQueryRepository.findTotalPage(size);

--- a/src/test/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementQueryRepositoryTest.java
+++ b/src/test/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementQueryRepositoryTest.java
@@ -15,8 +15,8 @@ import org.mju_likelion.festival.announcement.domain.Announcement;
 import org.mju_likelion.festival.announcement.domain.AnnouncementDetail;
 import org.mju_likelion.festival.announcement.domain.SimpleAnnouncement;
 import org.mju_likelion.festival.common.annotation.ApplicationTest;
+import org.mju_likelion.festival.common.enums.SortOrder;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,7 +52,7 @@ public class AnnouncementQueryRepositoryTest {
     // when & then
     IntStream.range(0, totalPages).forEach(page -> {
       List<SimpleAnnouncement> pageContent = announcementQueryRepository.findOrderedSimpleAnnouncementsWithPagenation(
-          Direction.ASC, page, pageSize);
+          SortOrder.ASC, page, pageSize);
 
       int expectedSize = calculateExpectedSize(page, pageSize, totalAnnouncementNum);
 
@@ -80,7 +80,7 @@ public class AnnouncementQueryRepositoryTest {
     // when & then
     IntStream.range(0, totalPages).forEach(page -> {
       List<SimpleAnnouncement> pageContent = announcementQueryRepository.findOrderedSimpleAnnouncementsWithPagenation(
-          Direction.DESC, page, pageSize);
+          SortOrder.DESC, page, pageSize);
 
       int expectedSize = calculateExpectedSize(page, pageSize, totalAnnouncementNum);
 

--- a/src/test/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemQueryRepositoryTest.java
+++ b/src/test/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemQueryRepositoryTest.java
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mju_likelion.festival.common.annotation.ApplicationTest;
+import org.mju_likelion.festival.common.enums.SortOrder;
 import org.mju_likelion.festival.lost_item.domain.SimpleLostItem;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,7 +50,7 @@ public class LostItemQueryRepositoryTest {
     // when & then
     IntStream.range(0, totalPages).forEach(page -> {
       List<SimpleLostItem> pageContent = lostItemQueryRepository.findOrderedSimpleLostItemsWithPagenation(
-          Direction.ASC, page, pageSize);
+          SortOrder.ASC, page, pageSize);
 
       int expectedSize = calculateExpectedSize(page, pageSize, totalLostItemNum);
 
@@ -74,7 +74,7 @@ public class LostItemQueryRepositoryTest {
     // when & then
     IntStream.range(0, totalPages).forEach(page -> {
       List<SimpleLostItem> pageContent = lostItemQueryRepository.findOrderedSimpleLostItemsWithPagenation(
-          Direction.DESC, page, pageSize);
+          SortOrder.DESC, page, pageSize);
 
       int expectedSize = calculateExpectedSize(page, pageSize, totalLostItemNum);
 


### PR DESCRIPTION
## Description
페이지네이션 시 음수 페이지 예외처리 추가
## Changes
### 정렬 순서 Enum
- [x] SortOrder
### SortOrder 를 사용하도록
- [x] AnnouncementController
- [x] AnnouncementQueryRepository
- [x] AnnouncementQueryService
- [x] LostItemController
- [x] LostItemQueryRepository
- [x] LostItemQueryService
- [x] AnnouncementQueryRepositoryTest
- [x] LostItemQueryRepositoryTest
### Page 번호 검사 커스텀 어노테이션
- [x] PageNumber
- [x] PageNumberValidator
### Page 크키 검사 커스텀 어노테이션
- [x] PageSize
- [x] PageSizeValidator
### @PageNumber, @PageSize 를 사용하도록
- [x] AnnouncementController
- [x] LostItemController
- [x] BoothController
## Additional context
Closes #92 