### PR TITLE
Feature/#96 분실물 작성 API 개발

### DIFF
--- a/src/main/java/org/mju_likelion/festival/announcement/dto/request/CreateAnnouncementRequest.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/dto/request/CreateAnnouncementRequest.java
@@ -1,6 +1,6 @@
 package org.mju_likelion.festival.announcement.dto.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,10 +11,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public class CreateAnnouncementRequest {
 
-  @NotNull(message = "제목은 필수 입력값입니다.")
+  @NotBlank(message = "제목은 필수 입력값입니다.")
   private String title;
 
-  @NotNull(message = "내용은 필수 입력값입니다.")
+  @NotBlank(message = "내용은 필수 입력값입니다.")
   private String content;
 
   private String imageUrl;

--- a/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/StudentCouncilAuthenticationInterceptor.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/StudentCouncilAuthenticationInterceptor.java
@@ -27,6 +27,7 @@ public class StudentCouncilAuthenticationInterceptor extends AbstractAuthenticat
     List<RequestMatcher> allowedRequestMatchers = new LinkedList<>();
     allowedRequestMatchers.add(new RequestMatcher(HttpMethod.GET, "/announcements"));
     allowedRequestMatchers.add(new RequestMatcher(HttpMethod.GET, "/announcements/{id}"));
+    allowedRequestMatchers.add(new RequestMatcher(HttpMethod.GET, "/lost-items"));
 
     return allowedRequestMatchers;
   }

--- a/src/main/java/org/mju_likelion/festival/common/config/AuthenticationConfig.java
+++ b/src/main/java/org/mju_likelion/festival/common/config/AuthenticationConfig.java
@@ -49,7 +49,8 @@ public class AuthenticationConfig implements WebMvcConfigurer {
   private void addStudentCouncilAuthenticationInterceptor(final InterceptorRegistry registry) {
     registry.addInterceptor(studentCouncilAuthenticationInterceptor)
         .addPathPatterns("/announcements")
-        .addPathPatterns("/announcements/{id}");
+        .addPathPatterns("/announcements/{id}")
+        .addPathPatterns("/lost-items");
   }
 
   /**

--- a/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
@@ -24,6 +24,10 @@ public enum ErrorType {
   INVALID_BOOTH_DESCRIPTION_LENGTH_ERROR(40014, "올바르지 않은 부스 설명 길이입니다."),
   INVALID_BOOTH_LOCATION_LENGTH_ERROR(40015, "올바르지 않은 부스 위치 길이입니다."),
   INVALID_SORT_ORDER_ERROR(40016, "올바르지 않은 정렬 순서입니다."),
+  INVALID_LOST_ITEM_TITLE_LENGTH_ERROR(40017, "올바르지 않은 분실물 제목 길이입니다."),
+  INVALID_LOST_ITEM_CONTENT_LENGTH_ERROR(40018, "올바르지 않은 분실물 내용 길이입니다."),
+  LOST_ITEM_IMAGE_MISSING_ERROR(40019, "분실물 이미지가 누락되었습니다."),
+  LOST_ITEM_WRITER_MISSING_ERROR(40020, "분실물 작성자가 누락되었습니다."),
 
   INVALID_CREDENTIALS_ERROR(40100, "아이디나 비밀번호가 일치하지 않습니다."),
   NOT_AUTHENTICATED_ERROR(40101, "인증되지 않았습니다."),

--- a/src/main/java/org/mju_likelion/festival/common/util/string/StringUtil.java
+++ b/src/main/java/org/mju_likelion/festival/common/util/string/StringUtil.java
@@ -5,7 +5,7 @@ package org.mju_likelion.festival.common.util.string;
  */
 public class StringUtil {
 
-  public static boolean isBlankOrLargerThan(String str, int length) {
-    return str.isBlank() || str.length() > length;
+  public static boolean isBlankOrLargerThan(final String str, final int length) {
+    return str == null || str.isBlank() || str.length() > length;
   }
 }

--- a/src/main/java/org/mju_likelion/festival/lost_item/controller/LostItemController.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/controller/LostItemController.java
@@ -1,13 +1,20 @@
 package org.mju_likelion.festival.lost_item.controller;
 
+import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.mju_likelion.festival.common.annotaion.page_number.PageNumber;
 import org.mju_likelion.festival.common.annotaion.page_size.PageSize;
+import org.mju_likelion.festival.common.authentication.AuthenticationPrincipal;
 import org.mju_likelion.festival.common.enums.SortOrder;
+import org.mju_likelion.festival.lost_item.dto.request.CreateLostItemRequest;
 import org.mju_likelion.festival.lost_item.dto.response.SimpleLostItemsResponse;
 import org.mju_likelion.festival.lost_item.service.LostItemQueryService;
+import org.mju_likelion.festival.lost_item.service.LostItemService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class LostItemController {
 
   private final LostItemQueryService lostItemQueryService;
+  private final LostItemService lostItemService;
 
   @GetMapping
   public ResponseEntity<SimpleLostItemsResponse> getLostItems(
@@ -39,4 +47,14 @@ public class LostItemController {
     return ResponseEntity.ok(
         lostItemQueryService.searchLostItems(SortOrder.fromString(sort), keyword, page, size));
   }
+
+  @PostMapping
+  public ResponseEntity<Void> createLostItem(
+      @RequestBody @Valid CreateLostItemRequest createLostItemRequest,
+      @AuthenticationPrincipal UUID studentCouncilId) {
+
+    lostItemService.createLostItem(createLostItemRequest, studentCouncilId);
+    return ResponseEntity.noContent().build();
+  }
+
 }

--- a/src/main/java/org/mju_likelion/festival/lost_item/domain/LostItem.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/domain/LostItem.java
@@ -1,5 +1,7 @@
 package org.mju_likelion.festival.lost_item.domain;
 
+import static org.mju_likelion.festival.common.exception.type.ErrorType.INVALID_LOST_ITEM_TITLE_LENGTH_ERROR;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -8,18 +10,17 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Transient;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.mju_likelion.festival.admin.domain.Admin;
 import org.mju_likelion.festival.common.domain.BaseEntity;
+import org.mju_likelion.festival.common.exception.BadRequestException;
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.mju_likelion.festival.common.util.string.StringUtil;
 import org.mju_likelion.festival.image.domain.Image;
 
 @Getter
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
 @Entity(name = "lost_item")
 public class LostItem extends BaseEntity {
 
@@ -46,4 +47,53 @@ public class LostItem extends BaseEntity {
   @OneToOne(optional = false, fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinColumn(nullable = false, name = "image_id")
   private Image image;
+
+  public LostItem(
+      final String title,
+      final String content,
+      final Image image,
+      final Admin writer) {
+
+    validate(title, content, image, writer);
+
+    this.title = title;
+    this.content = content;
+    this.image = image;
+    this.writer = writer;
+  }
+
+  private void validate(
+      final String title,
+      final String content,
+      final Image image,
+      final Admin writer) {
+    validateTitle(title);
+    validateContent(content);
+    validateImage(image);
+    validateWriter(writer);
+  }
+
+  private void validateTitle(final String title) {
+    if (StringUtil.isBlankOrLargerThan(title, TITLE_LENGTH)) {
+      throw new BadRequestException(INVALID_LOST_ITEM_TITLE_LENGTH_ERROR);
+    }
+  }
+
+  private void validateContent(final String content) {
+    if (StringUtil.isBlankOrLargerThan(content, CONTENT_LENGTH)) {
+      throw new BadRequestException(ErrorType.INVALID_LOST_ITEM_CONTENT_LENGTH_ERROR);
+    }
+  }
+
+  private void validateImage(final Image image) {
+    if (image == null) {
+      throw new BadRequestException(ErrorType.LOST_ITEM_IMAGE_MISSING_ERROR);
+    }
+  }
+
+  private void validateWriter(final Admin writer) {
+    if (writer == null) {
+      throw new BadRequestException(ErrorType.LOST_ITEM_WRITER_MISSING_ERROR);
+    }
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/lost_item/dto/request/CreateLostItemRequest.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/dto/request/CreateLostItemRequest.java
@@ -1,0 +1,22 @@
+package org.mju_likelion.festival.lost_item.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 분실물 등록 요청 DTO
+ */
+@Getter
+@AllArgsConstructor
+public class CreateLostItemRequest {
+
+  @NotBlank(message = "제목은 필수 입력값입니다.")
+  private String title;
+
+  @NotBlank(message = "내용은 필수 입력값입니다.")
+  private String content;
+
+  @NotBlank(message = "분실물 이미지는 필수 입력값입니다.")
+  private String imageUrl;
+}

--- a/src/main/java/org/mju_likelion/festival/lost_item/service/LostItemService.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/service/LostItemService.java
@@ -1,0 +1,43 @@
+package org.mju_likelion.festival.lost_item.service;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.ADMIN_NOT_FOUND_ERROR;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.mju_likelion.festival.admin.domain.Admin;
+import org.mju_likelion.festival.admin.domain.repository.AdminJpaRepository;
+import org.mju_likelion.festival.common.exception.NotFoundException;
+import org.mju_likelion.festival.image.domain.Image;
+import org.mju_likelion.festival.lost_item.domain.LostItem;
+import org.mju_likelion.festival.lost_item.domain.repository.LostItemJpaRepository;
+import org.mju_likelion.festival.lost_item.dto.request.CreateLostItemRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+@Transactional
+public class LostItemService {
+
+  private final LostItemJpaRepository lostItemJpaRepository;
+  private final AdminJpaRepository adminJpaRepository;
+
+  public void createLostItem(CreateLostItemRequest createLostItemRequest, UUID studentCouncilId) {
+
+    Admin admin = getExistAdmin(studentCouncilId);
+    Image image = new Image(createLostItemRequest.getImageUrl());
+
+    LostItem lostItem = new LostItem(
+        createLostItemRequest.getTitle(),
+        createLostItemRequest.getContent(),
+        image,
+        admin);
+
+    lostItemJpaRepository.save(lostItem);
+  }
+
+  private Admin getExistAdmin(UUID studentCouncilId) {
+    return adminJpaRepository.findById(studentCouncilId)
+        .orElseThrow(() -> new NotFoundException(ADMIN_NOT_FOUND_ERROR));
+  }
+}

--- a/src/test/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemQueryRepositoryTest.java
+++ b/src/test/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemQueryRepositoryTest.java
@@ -106,7 +106,7 @@ public class LostItemQueryRepositoryTest {
     Admin admin = new Admin("lost_item_admin", "1234", "분실물 관리자", AdminRole.STUDENT_COUNCIL, null,
         null);
     adminJpaRepository.saveAndFlush(admin);
-    LostItem lostItem = new LostItem(admin, "지갑 발견", "발견했습니다.", null, new Image("asdf"));
+    LostItem lostItem = new LostItem("지갑 발견", "발견했습니다.", new Image("asdf"), admin);
     lostItemJpaRepository.saveAndFlush(lostItem);
 
     // when & then
@@ -139,7 +139,7 @@ public class LostItemQueryRepositoryTest {
     Admin admin = new Admin("lost_item_admin", "1234", "분실물 관리자", AdminRole.STUDENT_COUNCIL, null,
         null);
     adminJpaRepository.saveAndFlush(admin);
-    LostItem lostItem = new LostItem(admin, "발견", "지갑 발견했습니다.", null, new Image("asdf"));
+    LostItem lostItem = new LostItem("발견", "지갑 발견했습니다.", new Image("asdf"), admin);
     lostItemJpaRepository.saveAndFlush(lostItem);
 
     // when & then


### PR DESCRIPTION
## Description
분실물 작성 API 개발
## Changes
### 분실물 생성자, validation
- [x] LostItem
### Service
- [x] LostItemService
### Controller
- [x] LostItemController
### 학생회만 가능하도록
- [x] AuthenticationConfig

### API
| URL                     | method | Usage                   | Authorization Needed |
| ------------------ | ---------| -------------------- | ------------------------ |
|             /lost-items               |       POST        |           분실물 작성                    |               O(학생회만)                     |

## Additional context
Closes #96 