### PR TITLE
Feature/#108 로깅 AOP 구현

### DIFF
--- a/.github/workflows/ci-cd-develop.yml
+++ b/.github/workflows/ci-cd-develop.yml
@@ -86,7 +86,7 @@ jobs:
             sudo docker pull ${{secrets.DOCKERHUB_USERNAME}}/${{secrets.DEV_DOCKERHUB_IMAGE}}
             sudo docker ps -q | xargs -r sudo docker stop
             sudo docker ps -aq | xargs -r sudo docker rm
-            sudo docker run --name ${{secrets.DEV_DOCKERHUB_IMAGE}} --rm -d -p 8080:8080 ${{secrets.DOCKERHUB_USERNAME}}/${{secrets.DEV_DOCKERHUB_IMAGE}}
+            sudo docker run --name ${{secrets.DEV_DOCKERHUB_IMAGE}} --rm -d -p 8080:8080 -v ~/logs:/logs ${{secrets.DOCKERHUB_USERNAME}}/${{secrets.DEV_DOCKERHUB_IMAGE}}
             sudo docker system prune -f
             
             

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/SimpleAnnouncement.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/SimpleAnnouncement.java
@@ -13,4 +13,14 @@ public class SimpleAnnouncement {
   private final String title;
   private final String content;
   private final LocalDateTime createdAt;
+
+  @Override
+  public String toString() {
+    return "SimpleAnnouncement{" +
+        "id=" + id +
+        ", title='" + title + '\'' +
+        ", content='" + content + '\'' +
+        ", createdAt=" + createdAt +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/announcement/dto/request/CreateAnnouncementRequest.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/dto/request/CreateAnnouncementRequest.java
@@ -18,4 +18,13 @@ public class CreateAnnouncementRequest {
   private String content;
 
   private String imageUrl;
+
+  @Override
+  public String toString() {
+    return "CreateAnnouncementRequest{" +
+        "title='" + title + '\'' +
+        ", content='" + content + '\'' +
+        ", imageUrl='" + imageUrl + '\'' +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/announcement/dto/request/UpdateAnnouncementRequest.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/dto/request/UpdateAnnouncementRequest.java
@@ -19,4 +19,13 @@ public class UpdateAnnouncementRequest {
   private String title;
   private String content;
   private FieldWrapper<String> imageUrl;
+
+  @Override
+  public String toString() {
+    return "UpdateAnnouncementRequest{" +
+        "title='" + title + '\'' +
+        ", content='" + content + '\'' +
+        ", imageUrl=" + imageUrl +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/announcement/dto/response/AnnouncementDetailResponse.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/dto/response/AnnouncementDetailResponse.java
@@ -30,4 +30,15 @@ public class AnnouncementDetailResponse {
         announcementDetail.getImageUrl()
     );
   }
+
+  @Override
+  public String toString() {
+    return "AnnouncementDetailResponse{" +
+        "id=" + id +
+        ", title='" + title + '\'' +
+        ", content='" + content + '\'' +
+        ", createdAt=" + createdAt +
+        ", imageUrl='" + imageUrl + '\'' +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/announcement/dto/response/SimpleAnnouncementsResponse.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/dto/response/SimpleAnnouncementsResponse.java
@@ -19,4 +19,12 @@ public class SimpleAnnouncementsResponse {
 
     return new SimpleAnnouncementsResponse(simpleAnnouncements, totalPage);
   }
+
+  @Override
+  public String toString() {
+    return "SimpleAnnouncementsResponse{" +
+        "simpleAnnouncements=" + simpleAnnouncements +
+        ", totalPage=" + totalPage +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/auth/dto/request/AdminLoginRequest.java
+++ b/src/main/java/org/mju_likelion/festival/auth/dto/request/AdminLoginRequest.java
@@ -19,4 +19,13 @@ public class AdminLoginRequest {
 
   @NotBlank(message = "키가 누락되었습니다.")
   private String key;
+
+  @Override
+  public String toString() {
+    return "AdminLoginRequest{" +
+        "encryptedLoginId='" + encryptedLoginId + '\'' +
+        ", encryptedPassword='" + encryptedPassword + '\'' +
+        ", key='" + key + '\'' +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/auth/dto/request/UserLoginRequest.java
+++ b/src/main/java/org/mju_likelion/festival/auth/dto/request/UserLoginRequest.java
@@ -28,4 +28,14 @@ public class UserLoginRequest {
   @NotNull(message = "동의 항목이 누락되었습니다.")
   @Size(min = 1, message = "적어도 하나의 동의 항목이 필요합니다.")
   private Map<UUID, @AssertTrue(message = "동의 항목에 동의해야 합니다.") Boolean> terms;
+
+  @Override
+  public String toString() {
+    return "UserLoginRequest{" +
+        "encryptedStudentId='" + encryptedStudentId + '\'' +
+        ", encryptedPassword='" + encryptedPassword + '\'' +
+        ", key='" + key + '\'' +
+        ", terms=" + terms +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/auth/dto/response/KeyResponse.java
+++ b/src/main/java/org/mju_likelion/festival/auth/dto/response/KeyResponse.java
@@ -14,4 +14,13 @@ public class KeyResponse {
   private final String rsaPublicKey;
   private final String credentialKey;
   private final RsaKeyStrategy rsaKeyStrategy;
+
+  @Override
+  public String toString() {
+    return "KeyResponse{" +
+        "rsaPublicKey='" + rsaPublicKey + '\'' +
+        ", credentialKey='" + credentialKey + '\'' +
+        ", rsaKeyStrategy=" + rsaKeyStrategy +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/auth/dto/response/LoginResponse.java
+++ b/src/main/java/org/mju_likelion/festival/auth/dto/response/LoginResponse.java
@@ -11,4 +11,11 @@ import lombok.Getter;
 public class LoginResponse {
 
   private final String accessToken;
+
+  @Override
+  public String toString() {
+    return "LoginResponse{" +
+        "accessToken='" + accessToken + '\'' +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/domain/BoothDetail.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/BoothDetail.java
@@ -28,4 +28,17 @@ public class BoothDetail extends SimpleBooth {
     this.locationImageUrl = locationImageUrl;
     this.createdAt = createdAt;
   }
+
+  @Override
+  public String toString() {
+    return "BoothDetail{" +
+        "id=" + id +
+        ", name='" + name + '\'' +
+        ", description='" + description + '\'' +
+        ", location='" + location + '\'' +
+        ", imageUrl='" + imageUrl + '\'' +
+        ", locationImageUrl='" + locationImageUrl + '\'' +
+        ", createdAt=" + createdAt +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/domain/SimpleBooth.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/SimpleBooth.java
@@ -15,4 +15,14 @@ public class SimpleBooth {
   protected final String name;
   protected final String description;
   protected final String imageUrl;
+
+  @Override
+  public String toString() {
+    return "SimpleBooth{" +
+        "id=" + id +
+        ", name='" + name + '\'' +
+        ", description='" + description + '\'' +
+        ", imageUrl='" + imageUrl + '\'' +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/dto/request/UpdateBoothRequest.java
+++ b/src/main/java/org/mju_likelion/festival/booth/dto/request/UpdateBoothRequest.java
@@ -15,4 +15,15 @@ public class UpdateBoothRequest {
   private String location;
   private String locationImageUrl;
   private String imageUrl;
+
+  @Override
+  public String toString() {
+    return "UpdateBoothRequest{" +
+        "name='" + name + '\'' +
+        ", description='" + description + '\'' +
+        ", location='" + location + '\'' +
+        ", locationImageUrl='" + locationImageUrl + '\'' +
+        ", imageUrl='" + imageUrl + '\'' +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/dto/response/BoothDetailResponse.java
+++ b/src/main/java/org/mju_likelion/festival/booth/dto/response/BoothDetailResponse.java
@@ -27,4 +27,17 @@ public class BoothDetailResponse {
         boothDetail.getDescription(), boothDetail.getLocation(), boothDetail.getImageUrl(),
         boothDetail.getLocationImageUrl(), boothDetail.getCreatedAt());
   }
+
+  @Override
+  public String toString() {
+    return "BoothDetailResponse{" +
+        "id=" + id +
+        ", name='" + name + '\'' +
+        ", description='" + description + '\'' +
+        ", location='" + location + '\'' +
+        ", imageUrl='" + imageUrl + '\'' +
+        ", locationImageUrl='" + locationImageUrl + '\'' +
+        ", createdAt=" + createdAt +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/dto/response/BoothQrResponse.java
+++ b/src/main/java/org/mju_likelion/festival/booth/dto/response/BoothQrResponse.java
@@ -11,4 +11,11 @@ import lombok.Getter;
 public class BoothQrResponse {
 
   private final String qrCode;
+
+  @Override
+  public String toString() {
+    return "BoothQrResponse{" +
+        "qrCode='" + qrCode + '\'' +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/dto/response/SimpleBoothsResponse.java
+++ b/src/main/java/org/mju_likelion/festival/booth/dto/response/SimpleBoothsResponse.java
@@ -21,4 +21,12 @@ public class SimpleBoothsResponse {
 
     return new SimpleBoothsResponse(simpleBooths, totalPage);
   }
+
+  @Override
+  public String toString() {
+    return "SimpleBoothsResponse{" +
+        "simpleBooths=" + simpleBooths +
+        ", totalPage=" + totalPage +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/AbstractAuthenticationInterceptor.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/AbstractAuthenticationInterceptor.java
@@ -42,6 +42,8 @@ public abstract class AbstractAuthenticationInterceptor implements HandlerInterc
         .orElseThrow(() -> new UnauthorizedException(JWT_NOT_FOUND_ERROR));
     Payload payload = userJwtUtil.getPayload(accessToken);
 
+    request.setAttribute("userId", payload.getId().toString());
+
     if (!isAuthorized(payload)) {
       throw new ForbiddenException(getErrorType());
     }

--- a/src/main/java/org/mju_likelion/festival/common/config/WebConfig.java
+++ b/src/main/java/org/mju_likelion/festival/common/config/WebConfig.java
@@ -1,18 +1,23 @@
 package org.mju_likelion.festival.common.config;
 
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.mju_likelion.festival.common.logging.RequestIdInterceptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
   private static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";
   private final long MAX_AGE_SECS = 3600;
+  private final RequestIdInterceptor requestIdInterceptor;
   @Value("${client.hosts}")
   private List<String> clientHosts;
 
@@ -29,5 +34,11 @@ public class WebConfig implements WebMvcConfigurer {
   @Bean
   public RestTemplate restTemplate() {
     return new RestTemplate();
+  }
+
+  @Override
+  public void addInterceptors(final InterceptorRegistry registry) {
+    registry.addInterceptor(requestIdInterceptor)
+        .addPathPatterns("/**");
   }
 }

--- a/src/main/java/org/mju_likelion/festival/common/exception/controller/ExceptionController.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/controller/ExceptionController.java
@@ -27,7 +27,6 @@ public class ExceptionController {
 
   @ExceptionHandler(CustomException.class)
   public ResponseEntity<ErrorResponse> customExceptionHandler(final CustomException e) {
-    writeLog(e);
     return ResponseEntity.status(e.getHttpStatus()).body(ErrorResponse.res(e));
   }
 
@@ -41,7 +40,6 @@ public class ExceptionController {
     BadRequestException badRequestException = new BadRequestException(
         ErrorType.INVALID_REQUEST_BODY_ERROR, message);
 
-    writeLog(badRequestException);
     return ResponseEntity.badRequest().body(ErrorResponse.res(badRequestException));
   }
 
@@ -57,7 +55,6 @@ public class ExceptionController {
     BadRequestException badRequestException = new BadRequestException(
         ErrorType.INVALID_REQUEST_PARAMETER_ERROR, failedParameter);
 
-    writeLog(badRequestException);
     return ResponseEntity.badRequest().body(ErrorResponse.res(badRequestException));
   }
 
@@ -69,7 +66,6 @@ public class ExceptionController {
     BadRequestException badRequestException = new BadRequestException(
         ErrorType.INVALID_REQUEST_PARAMETER_ERROR, e.getName());
 
-    writeLog(badRequestException);
     return ResponseEntity.badRequest().body(ErrorResponse.res(badRequestException));
   }
 
@@ -81,7 +77,6 @@ public class ExceptionController {
     BadRequestException badRequestException = new BadRequestException(
         ErrorType.MISSING_REQUEST_PARAMETER_ERROR, e.getParameterName());
 
-    writeLog(badRequestException);
     return ResponseEntity.badRequest().body(ErrorResponse.res(badRequestException));
   }
 
@@ -93,7 +88,6 @@ public class ExceptionController {
     BadRequestException badRequestException = new BadRequestException(
         ErrorType.INVALID_REQUEST_FORMAT_ERROR);
 
-    writeLog(badRequestException);
     return ResponseEntity.badRequest().body(ErrorResponse.res(badRequestException));
   }
 
@@ -105,7 +99,6 @@ public class ExceptionController {
     BadRequestException badRequestException = new BadRequestException(
         ErrorType.METHOD_NOT_ALLOWED_ERROR, httpRequestMethodNotSupportedException.getMessage());
 
-    writeLog(badRequestException);
     return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
         .body(ErrorResponse.res(badRequestException));
   }
@@ -118,7 +111,6 @@ public class ExceptionController {
     BadRequestException badRequestException = new BadRequestException(
         ErrorType.NO_RESOURCE_ERROR, noResourceFoundException.getMessage());
 
-    writeLog(badRequestException);
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.res(badRequestException));
   }
 
@@ -130,8 +122,6 @@ public class ExceptionController {
     BadRequestException badRequestException = new BadRequestException(
         ErrorType.HTTP_MEDIA_TYPE_NOT_ACCEPTABLE_ERROR,
         httpMediaTypeNotAcceptableException.getMessage());
-
-    writeLog(badRequestException);
 
     return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
         .body(ErrorResponse.res(badRequestException));
@@ -145,30 +135,12 @@ public class ExceptionController {
     BadRequestException badRequestException = new BadRequestException(
         HTTP_MEDIA_TYPE_NOT_SUPPORTED_ERROR, httpMediaTypeNotSupportedException.getMessage());
 
-    writeLog(badRequestException);
     return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
         .body(ErrorResponse.res(badRequestException));
   }
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> exceptionHandler(final Exception e) {
-    writeLog(e);
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ErrorResponse.res(e));
-  }
-
-  private void writeLog(final CustomException customException) {
-    ErrorType errorType = customException.getErrorType();
-
-    String exceptionName = customException.getClass().getSimpleName();
-    String message = errorType.getMessage();
-    String detail = customException.getDetail();
-
-    log.error("[{}]{}:{}", exceptionName, message, detail);
-  }
-
-  private void writeLog(final Exception exception) {
-    String exceptionName = exception.getClass().getSimpleName();
-    String message = exception.getMessage();
-    log.error("[{}]:{}", exceptionName, message);
   }
 }

--- a/src/main/java/org/mju_likelion/festival/common/logging/LoggingAspect.java
+++ b/src/main/java/org/mju_likelion/festival/common/logging/LoggingAspect.java
@@ -1,0 +1,83 @@
+package org.mju_likelion.festival.common.logging;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.Signature;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class LoggingAspect {
+
+  private final HttpServletRequest request;
+
+  public LoggingAspect(HttpServletRequest request) {
+    this.request = request;
+  }
+
+  @Pointcut("@annotation(org.springframework.web.bind.annotation.GetMapping)")
+  private void getMapping() {
+  }
+
+  @Pointcut("@annotation(org.springframework.web.bind.annotation.PostMapping)")
+  private void postMapping() {
+  }
+
+  @Pointcut("@annotation(org.springframework.web.bind.annotation.PutMapping)")
+  private void putMapping() {
+  }
+
+  @Pointcut("@annotation(org.springframework.web.bind.annotation.DeleteMapping)")
+  private void deleteMapping() {
+  }
+
+  @Pointcut("@annotation(org.springframework.web.bind.annotation.PatchMapping)")
+  private void patchMapping() {
+  }
+
+  @Pointcut("getMapping() || postMapping() || putMapping() || deleteMapping() || patchMapping()")
+  private void allMapping() {
+  }
+
+  @Pointcut("execution(* org.mju_likelion.festival.*.controller.*Controller.*(..))")
+  private void controllerPointCut() {
+  }
+
+  @Pointcut("@annotation(org.springframework.web.bind.annotation.ExceptionHandler)")
+  private void exceptionHandlerCut() {
+  }
+
+  @Before("allMapping()")
+  public void requestLog(final JoinPoint joinPoint) {
+    Signature signature = joinPoint.getSignature();
+    String requestId = (String) request.getAttribute("requestId");
+    String methodArguments = Arrays.stream(joinPoint.getArgs())
+        .map(arg -> arg == null ? "null" : arg.toString())
+        .collect(Collectors.joining(", "));
+
+    log.info(">> REQUEST >> [ID: {}] Controller: {} || Method: {}() || Arguments: [{}]",
+        requestId,
+        joinPoint.getTarget().getClass().getSimpleName(),
+        signature.getName(),
+        methodArguments);
+  }
+
+  @AfterReturning(value = "controllerPointCut() || exceptionHandlerCut()", returning = "response")
+  public void responseLog(final JoinPoint joinPoint, final ResponseEntity<?> response) {
+    Signature signature = joinPoint.getSignature();
+    log.info("<< RESPONSE << [ID: {}] Controller: {} || Method: {}() || ResponseBody: {}",
+        request.getAttribute("requestId"),
+        joinPoint.getTarget().getClass().getSimpleName(),
+        signature.getName(),
+        response.getBody());
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/logging/LoggingAspect.java
+++ b/src/main/java/org/mju_likelion/festival/common/logging/LoggingAspect.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.Signature;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
@@ -58,26 +57,34 @@ public class LoggingAspect {
 
   @Before("allMapping()")
   public void requestLog(final JoinPoint joinPoint) {
-    Signature signature = joinPoint.getSignature();
     String requestId = (String) request.getAttribute("requestId");
+    String userId = (String) request.getAttribute("userId");
     String methodArguments = Arrays.stream(joinPoint.getArgs())
         .map(arg -> arg == null ? "null" : arg.toString())
         .collect(Collectors.joining(", "));
 
-    log.info(">> REQUEST >> [ID: {}] Controller: {} || Method: {}() || Arguments: [{}]",
+    log.info(
+        ">> REQUEST >> [ID: {}, USERID: {}] Controller: {} || Method: {}() || Arguments: [{}]",
         requestId,
+        userId,
         joinPoint.getTarget().getClass().getSimpleName(),
-        signature.getName(),
-        methodArguments);
+        joinPoint.getSignature().getName(),
+        methodArguments
+    );
   }
 
   @AfterReturning(value = "controllerPointCut() || exceptionHandlerCut()", returning = "response")
   public void responseLog(final JoinPoint joinPoint, final ResponseEntity<?> response) {
-    Signature signature = joinPoint.getSignature();
-    log.info("<< RESPONSE << [ID: {}] Controller: {} || Method: {}() || ResponseBody: {}",
-        request.getAttribute("requestId"),
+    String requestId = (String) request.getAttribute("requestId");
+    String userId = (String) request.getAttribute("userId");
+
+    log.info(
+        "<< RESPONSE << [ID: {}, USERID: {}] Controller: {} || Method: {}() || ResponseBody: {}",
+        requestId,
+        userId,
         joinPoint.getTarget().getClass().getSimpleName(),
-        signature.getName(),
-        response.getBody());
+        joinPoint.getSignature().getName(),
+        response.getBody()
+    );
   }
 }

--- a/src/main/java/org/mju_likelion/festival/common/logging/RequestIdInterceptor.java
+++ b/src/main/java/org/mju_likelion/festival/common/logging/RequestIdInterceptor.java
@@ -1,0 +1,32 @@
+package org.mju_likelion.festival.common.logging;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class RequestIdInterceptor implements HandlerInterceptor {
+
+  @Override
+  public boolean preHandle(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final Object handler) {
+
+    String requestId = UUID.randomUUID().toString();
+    request.setAttribute("requestId", requestId);
+    return true;
+  }
+
+  @Override
+  public void afterCompletion(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final Object handler,
+      final Exception ex) {
+
+    request.removeAttribute("requestId");
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/image/dto/response/ImageResponse.java
+++ b/src/main/java/org/mju_likelion/festival/image/dto/response/ImageResponse.java
@@ -14,4 +14,11 @@ public class ImageResponse {
   public static ImageResponse from(final Image image) {
     return new ImageResponse(image.getUrl());
   }
+
+  @Override
+  public String toString() {
+    return "ImageResponse{" +
+        "url='" + url + '\'' +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/lost_item/domain/SimpleLostItem.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/domain/SimpleLostItem.java
@@ -15,4 +15,16 @@ public class SimpleLostItem {
   private final String imageUrl;
   private final LocalDateTime createdAt;
   private final Boolean isFounded;
+
+  @Override
+  public String toString() {
+    return "SimpleLostItem{" +
+        "id=" + id +
+        ", title='" + title + '\'' +
+        ", content='" + content + '\'' +
+        ", imageUrl='" + imageUrl + '\'' +
+        ", createdAt=" + createdAt +
+        ", isFounded=" + isFounded +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/lost_item/dto/request/CreateLostItemRequest.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/dto/request/CreateLostItemRequest.java
@@ -19,4 +19,13 @@ public class CreateLostItemRequest {
 
   @NotBlank(message = "분실물 이미지는 필수 입력값입니다.")
   private String imageUrl;
+
+  @Override
+  public String toString() {
+    return "CreateLostItemRequest{" +
+        "title='" + title + '\'' +
+        ", content='" + content + '\'' +
+        ", imageUrl='" + imageUrl + '\'' +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/lost_item/dto/request/LostItemFoundRequest.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/dto/request/LostItemFoundRequest.java
@@ -13,4 +13,11 @@ public class LostItemFoundRequest {
 
   @NotBlank(message = "수령인 정보는 필수값입니다.")
   private String retrieverInfo;
+
+  @Override
+  public String toString() {
+    return "LostItemFoundRequest{" +
+        "retrieverInfo='" + retrieverInfo + '\'' +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/lost_item/dto/request/UpdateLostItemRequest.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/dto/request/UpdateLostItemRequest.java
@@ -13,4 +13,13 @@ public class UpdateLostItemRequest {
   private String title;
   private String content;
   private String imageUrl;
+
+  @Override
+  public String toString() {
+    return "UpdateLostItemRequest{" +
+        "title='" + title + '\'' +
+        ", content='" + content + '\'' +
+        ", imageUrl='" + imageUrl + '\'' +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/lost_item/dto/response/SimpleLostItemsResponse.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/dto/response/SimpleLostItemsResponse.java
@@ -22,4 +22,12 @@ public class SimpleLostItemsResponse {
 
     return new SimpleLostItemsResponse(simpleLostItem, totalPage);
   }
+
+  @Override
+  public String toString() {
+    return "SimpleLostItemsResponse{" +
+        "simpleLostItems=" + simpleLostItems +
+        ", totalPage=" + totalPage +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/term/controller/TermController.java
+++ b/src/main/java/org/mju_likelion/festival/term/controller/TermController.java
@@ -2,7 +2,7 @@ package org.mju_likelion.festival.term.controller;
 
 import java.util.List;
 import lombok.AllArgsConstructor;
-import org.mju_likelion.festival.term.dto.TermResponse;
+import org.mju_likelion.festival.term.dto.response.TermResponse;
 import org.mju_likelion.festival.term.service.TermQueryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/org/mju_likelion/festival/term/domain/SimpleTerm.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/SimpleTerm.java
@@ -14,4 +14,13 @@ public class SimpleTerm {
   private final UUID id;
   private final String title;
   private final String content;
+
+  @Override
+  public String toString() {
+    return "SimpleTerm{" +
+        "id=" + id +
+        ", title='" + title + '\'' +
+        ", content='" + content + '\'' +
+        '}';
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/term/dto/response/TermResponse.java
+++ b/src/main/java/org/mju_likelion/festival/term/dto/response/TermResponse.java
@@ -1,4 +1,4 @@
-package org.mju_likelion.festival.term.dto;
+package org.mju_likelion.festival.term.dto.response;
 
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -18,5 +18,14 @@ public class TermResponse {
 
   public static TermResponse of(final SimpleTerm simpleTerm) {
     return new TermResponse(simpleTerm.getId(), simpleTerm.getTitle(), simpleTerm.getContent());
+  }
+
+  @Override
+  public String toString() {
+    return "TermResponse{" +
+        "id=" + id +
+        ", title='" + title + '\'' +
+        ", content='" + content + '\'' +
+        '}';
   }
 }

--- a/src/main/java/org/mju_likelion/festival/term/service/TermQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/term/service/TermQueryService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import org.mju_likelion.festival.term.domain.repository.TermQueryRepository;
-import org.mju_likelion.festival.term.dto.TermResponse;
+import org.mju_likelion.festival.term.dto.response.TermResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,51 @@
+<configuration>
+
+  <!-- Console appender with color coding -->
+  <appender class="ch.qos.logback.core.ConsoleAppender" name="CONSOLE">
+    <encoder>
+      <!-- Define pattern with ANSI color codes for console logging -->
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- Rolling File appender for request logs (INFO, WARN, ERROR) -->
+  <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="REQUEST_FILE">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %msg%n%n</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>logs/request-response/request-response[%d{yyyy-MM-dd}].log</fileNamePattern>
+      <maxHistory>10</maxHistory>
+    </rollingPolicy>
+  </appender>
+
+  <!-- Rolling File appender for SQL logs -->
+  <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="SQL_FILE">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %msg%n-----------------------------------------%n</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>logs/hibernate-sql/hibernate-sql[%d{yyyy-MM-dd}].log</fileNamePattern>
+      <maxHistory>10</maxHistory>
+    </rollingPolicy>
+  </appender>
+
+  <!-- SQL logging configuration -->
+  <logger level="DEBUG" name="org.hibernate.SQL">
+    <appender-ref ref="SQL_FILE"/>
+  </logger>
+  <logger level="TRACE" name="org.hibernate.type.descriptor.sql.BasicBinder">
+    <appender-ref ref="SQL_FILE"/>
+  </logger>
+
+  <!-- Root logger configuration for request logs -->
+  <logger level="DEBUG" name="org.mju_likelion.festival.common.logging.LoggingAspect">
+    <appender-ref ref="REQUEST_FILE"/>
+  </logger>
+
+  <!-- Root logger configuration for console output -->
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
## Description
로깅 AOP 구현
## Changes
### 로깅을 위한 toString 오버라이딩
- [x] SimpleAnnouncement
- [x] CreateAnnouncementRequest
- [x] UpdateAnnouncementRequest
- [x] AnnouncementDetailResponse
- [x] SimpleAnnouncementsResponse
- [x] AdminLoginRequest
- [x] UserLoginRequest
- [x] KeyResponse
- [x] LoginResponse
- [x] BoothDetail
- [x] SimpleBooth
- [x] UpdateBoothRequest
- [x] BoothDetailResponse
- [x] BoothQrResponse
- [x] SimpleBoothsResponse
- [x] ImageResponse
- [x] SimpleLostItem
- [x] CreateLostItemRequest
- [x] LostItemFoundRequest
- [x] UpdateLostItemRequest
- [x] SimpleLostItemsResponse
- [x] SimpleTerm
- [x] TermResponse
### 로깅 설정 파일 작성
- [x] logback-spring
### RequestIdInterceptor 작성 - 각 Request 에 ID 를 부여해 식별하기 위함
- [x] RequestIdInterceptor
- [x] WebConfig
### 로깅 AOP 
- [x] LoggingAspect
### ExceptionController 에서 로깅하지 않도록
- [x] ExceptionController
### ci-cd 스크립트 변경
- [x] ci-cd-develop
## Additional context