### PR TITLE
Feature/#114 분실물 검색 시 URI 충돌 수정

### DIFF
--- a/src/main/java/org/mju_likelion/festival/common/config/AuthenticationConfig.java
+++ b/src/main/java/org/mju_likelion/festival/common/config/AuthenticationConfig.java
@@ -52,7 +52,8 @@ public class AuthenticationConfig implements WebMvcConfigurer {
         .addPathPatterns("/announcements/{id}")
         .addPathPatterns("/lost-items")
         .addPathPatterns("/lost-items/{id}")
-        .addPathPatterns("/lost-items/{id}/found");
+        .addPathPatterns("/lost-items/{id}/found")
+        .excludePathPatterns("/lost-items/search");
   }
 
   /**


### PR DESCRIPTION
## Description
분실물 검색 시 URI 충돌 수정
## Changes
### Authentication 인터셉터 Config
- [x] AuthenticationConfig

## Additional context
기존 /lost-items/{id} 가 인터셉터 등록 대상이었음
/lost-items/search 요청 시 {id} 에 search 가 들어가는 현상 발견
/lost-items/search 를 exclude 함
Closes #114 