### PR TITLE
Feature/#120 Lombok 을 사용해 toString 을 오버라이딩하도록 변경, 필요 없는 Lombok 어노테이션 제거

### DIFF
--- a/src/main/java/org/mju_likelion/festival/admin/domain/Admin.java
+++ b/src/main/java/org/mju_likelion/festival/admin/domain/Admin.java
@@ -6,16 +6,14 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Transient;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.mju_likelion.festival.common.domain.BaseEntity;
 
 @Getter
-@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
+@ToString(callSuper = true, of = {"loginId", "name", "role"})
 @Entity(name = "admin")
 public class Admin extends BaseEntity {
 

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/Announcement.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/Announcement.java
@@ -11,8 +11,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Transient;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.mju_likelion.festival.admin.domain.Admin;
 import org.mju_likelion.festival.common.domain.BaseEntity;
 import org.mju_likelion.festival.common.exception.BadRequestException;
@@ -20,7 +22,8 @@ import org.mju_likelion.festival.common.util.string.StringUtil;
 import org.mju_likelion.festival.image.domain.Image;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(callSuper = true, of = {"title", "content", "image", "writer"})
 @Entity(name = "announcement")
 public class Announcement extends BaseEntity {
 

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementJpaRepository.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementJpaRepository.java
@@ -1,6 +1,5 @@
 package org.mju_likelion.festival.announcement.domain.repository;
 
-import java.util.List;
 import java.util.UUID;
 import org.mju_likelion.festival.announcement.domain.Announcement;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,10 +8,4 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AnnouncementJpaRepository extends JpaRepository<Announcement, UUID> {
 
-  /**
-   * 작성자를 기준으로 공지사항을 조회한다.
-   * <p>
-   * 테스트에서만 사용한다.
-   */
-  List<Announcement> findByWriterId(final UUID writerId);
 }

--- a/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Transient;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.mju_likelion.festival.admin.domain.Admin;
 import org.mju_likelion.festival.common.domain.BaseEntity;
 import org.mju_likelion.festival.common.exception.BadRequestException;
@@ -22,6 +23,8 @@ import org.mju_likelion.festival.image.domain.Image;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(callSuper = true,
+    of = {"name", "description", "location", "sequence", "locationImage", "image"})
 @Entity(name = "booth")
 public class Booth extends BaseEntity {
 

--- a/src/main/java/org/mju_likelion/festival/booth/domain/BoothUser.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/BoothUser.java
@@ -25,6 +25,11 @@ public class BoothUser extends BaseEntity {
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
+  public BoothUser(final Booth booth, final User user) {
+    this.booth = booth;
+    this.user = user;
+  }
+
   /**
    * 사용자와 부스가 자신의 사용자와 부스와 같은지 확인한다.
    *

--- a/src/main/java/org/mju_likelion/festival/booth/domain/BoothUser.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/BoothUser.java
@@ -4,17 +4,16 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.mju_likelion.festival.common.domain.BaseEntity;
 import org.mju_likelion.festival.user.domain.User;
 
 @Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(callSuper = true, of = {"booth", "user"})
 @Entity(name = "booth_user")
 public class BoothUser extends BaseEntity {
 

--- a/src/main/java/org/mju_likelion/festival/booth/domain/BoothUsers.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/BoothUsers.java
@@ -8,10 +8,12 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 import java.util.HashSet;
 import java.util.Set;
+import lombok.ToString;
 import org.mju_likelion.festival.common.exception.ConflictException;
 import org.mju_likelion.festival.user.domain.User;
 
 @Embeddable
+@ToString(callSuper = true, of = {"boothUsers"})
 public class BoothUsers {
 
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/src/main/java/org/mju_likelion/festival/booth/domain/BoothUsers.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/BoothUsers.java
@@ -28,12 +28,9 @@ public class BoothUsers {
   public void visit(final User user, final Booth booth) {
     validateVisitBooth(user, booth);
 
-    BoothUser boothUser = BoothUser.builder()
-        .user(user)
-        .booth(booth)
-        .build();
+    BoothUser boothUser = new BoothUser(booth, user);
 
-    this.boothUsers.add(boothUser);
+    boothUsers.add(boothUser);
   }
 
   /**
@@ -56,7 +53,7 @@ public class BoothUsers {
    * @return 사용자가 부스를 방문했는지 여부
    */
   private boolean isVisitedBooth(final User user, final Booth booth) {
-    return this.boothUsers.stream()
+    return boothUsers.stream()
         .anyMatch(boothUser -> boothUser.isSameUserAndBooth(user, booth));
   }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/domain/repository/BoothUserJpaRepository.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/repository/BoothUserJpaRepository.java
@@ -1,22 +1,11 @@
 package org.mju_likelion.festival.booth.domain.repository;
 
-import java.util.Optional;
 import java.util.UUID;
-import org.mju_likelion.festival.booth.domain.Booth;
 import org.mju_likelion.festival.booth.domain.BoothUser;
-import org.mju_likelion.festival.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoothUserJpaRepository extends JpaRepository<BoothUser, UUID> {
 
-  /**
-   * 사용자와 부스로 부스 사용자 조회. 테스트 코드 작성을 위해 추가함.
-   *
-   * @param user  사용자
-   * @param booth 부스
-   * @return 부스 사용자
-   */
-  Optional<BoothUser> findByUserAndBooth(final User user, final Booth booth);
 }

--- a/src/main/java/org/mju_likelion/festival/common/domain/BaseEntity.java
+++ b/src/main/java/org/mju_likelion/festival/common/domain/BaseEntity.java
@@ -9,12 +9,14 @@ import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
+import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @MappedSuperclass
+@ToString(of = "id")
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 

--- a/src/main/java/org/mju_likelion/festival/image/domain/Image.java
+++ b/src/main/java/org/mju_likelion/festival/image/domain/Image.java
@@ -8,12 +8,14 @@ import jakarta.persistence.Transient;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.mju_likelion.festival.common.domain.BaseEntity;
 import org.mju_likelion.festival.common.exception.BadRequestException;
 import org.mju_likelion.festival.common.util.string.StringUtil;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(callSuper = true, of = {"url"})
 @Entity(name = "image")
 public class Image extends BaseEntity {
 

--- a/src/main/java/org/mju_likelion/festival/lost_item/domain/LostItem.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/domain/LostItem.java
@@ -11,8 +11,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Transient;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.mju_likelion.festival.admin.domain.Admin;
 import org.mju_likelion.festival.common.domain.BaseEntity;
 import org.mju_likelion.festival.common.exception.BadRequestException;
@@ -22,7 +24,8 @@ import org.mju_likelion.festival.common.util.string.StringUtil;
 import org.mju_likelion.festival.image.domain.Image;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(callSuper = true, of = {"title", "content", "retrieverInfo", "image", "writer"})
 @Entity(name = "lost_item")
 public class LostItem extends BaseEntity {
 
@@ -32,10 +35,6 @@ public class LostItem extends BaseEntity {
   private final int CONTENT_LENGTH = 100;
   @Transient
   private final int OWNER_INFO_LENGTH = 150;
-
-  @ManyToOne(optional = false, fetch = FetchType.LAZY)
-  @JoinColumn(name = "writer_id", nullable = false)
-  private Admin writer;
 
   @Column(nullable = false, length = TITLE_LENGTH)
   private String title;
@@ -49,6 +48,10 @@ public class LostItem extends BaseEntity {
   @OneToOne(optional = false, fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinColumn(nullable = false, name = "image_id")
   private Image image;
+
+  @ManyToOne(optional = false, fetch = FetchType.LAZY)
+  @JoinColumn(nullable = false, name = "writer_id")
+  private Admin writer;
 
   public LostItem(
       final String title,

--- a/src/main/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemJpaRepository.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemJpaRepository.java
@@ -1,6 +1,5 @@
 package org.mju_likelion.festival.lost_item.domain.repository;
 
-import java.util.List;
 import java.util.UUID;
 import org.mju_likelion.festival.lost_item.domain.LostItem;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,13 +8,4 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface LostItemJpaRepository extends JpaRepository<LostItem, UUID> {
 
-  /**
-   * 작성자 ID로 분실물을 조회한다.
-   * <p>
-   * 테스트에서만 사용
-   *
-   * @param writerId 작성자 ID
-   * @return 분실물 목록
-   */
-  List<LostItem> findByWriterId(final UUID writerId);
 }

--- a/src/main/java/org/mju_likelion/festival/term/domain/Term.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/Term.java
@@ -4,10 +4,15 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Transient;
 import java.util.Objects;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.mju_likelion.festival.common.domain.BaseEntity;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(callSuper = true, of = {"title", "content", "sequence"})
 @Entity(name = "term")
 public class Term extends BaseEntity {
 
@@ -24,14 +29,6 @@ public class Term extends BaseEntity {
 
   @Column(nullable = false)
   private Short sequence;
-
-  @Override
-  public String toString() {
-    return "Term{" +
-        "title='" + title + '\'' +
-        ", content='" + content + '\'' +
-        '}';
-  }
 
   @Override
   public boolean equals(Object o) {

--- a/src/main/java/org/mju_likelion/festival/term/domain/TermUser.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/TermUser.java
@@ -5,17 +5,15 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.mju_likelion.festival.common.domain.BaseEntity;
 import org.mju_likelion.festival.user.domain.User;
 
 @Getter
-@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
+@ToString(callSuper = true, of = {"user", "term"})
 @Entity(name = "term_user")
 public class TermUser extends BaseEntity {
 

--- a/src/main/java/org/mju_likelion/festival/term/domain/TermUser.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/TermUser.java
@@ -25,12 +25,9 @@ public class TermUser extends BaseEntity {
   @JoinColumn(name = "term_id", nullable = false)
   private Term term;
 
-  @Override
-  public String toString() {
-    return "TermUser{" +
-        "user=" + user +
-        ", term=" + term +
-        '}';
+  public TermUser(final User user, final Term term) {
+    this.user = user;
+    this.term = term;
   }
 
   @Override

--- a/src/main/java/org/mju_likelion/festival/term/domain/TermUsers.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/TermUsers.java
@@ -6,19 +6,18 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 import java.util.HashSet;
 import java.util.Set;
+import lombok.ToString;
 import org.mju_likelion.festival.user.domain.User;
 
 @Embeddable
+@ToString(callSuper = true, of = {"termUsers"})
 public class TermUsers {
 
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
   private Set<TermUser> termUsers = new HashSet<>();
 
   public void agree(final Term term, final User user) {
-    TermUser termUser = TermUser.builder()
-        .term(term)
-        .user(user)
-        .build();
+    TermUser termUser = new TermUser(user, term);
     this.termUsers.add(termUser);
   }
 }

--- a/src/main/java/org/mju_likelion/festival/user/domain/User.java
+++ b/src/main/java/org/mju_likelion/festival/user/domain/User.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.mju_likelion.festival.booth.domain.Booth;
 import org.mju_likelion.festival.booth.domain.BoothUsers;
 import org.mju_likelion.festival.common.domain.BaseEntity;
@@ -16,6 +17,7 @@ import org.mju_likelion.festival.term.domain.TermUsers;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(callSuper = true, of = {"studentId"})
 @Entity(name = "user")
 public class User extends BaseEntity {
 
@@ -43,13 +45,6 @@ public class User extends BaseEntity {
 
   public void visitBooth(final Booth booth) {
     this.boothUsers.visit(this, booth);
-  }
-
-  @Override
-  public String toString() {
-    return "User{" +
-        "studentId='" + studentId + '\'' +
-        '}';
   }
 
   @Override

--- a/src/test/java/org/mju_likelion/festival/admin/domain/repository/AdminJpaRepository.java
+++ b/src/test/java/org/mju_likelion/festival/admin/domain/repository/AdminJpaRepository.java
@@ -1,0 +1,12 @@
+package org.mju_likelion.festival.admin.domain.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.mju_likelion.festival.admin.domain.Admin;
+import org.mju_likelion.festival.admin.domain.AdminRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminJpaRepository extends JpaRepository<Admin, UUID> {
+
+  Optional<Admin> findByRole(final AdminRole role);
+}

--- a/src/test/java/org/mju_likelion/festival/admin/domain/repository/AdminJpaRepository.java
+++ b/src/test/java/org/mju_likelion/festival/admin/domain/repository/AdminJpaRepository.java
@@ -8,5 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AdminJpaRepository extends JpaRepository<Admin, UUID> {
 
+  Optional<Admin> findByLoginIdAndPassword(final String loginId, final String password);
+
   Optional<Admin> findByRole(final AdminRole role);
 }

--- a/src/test/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementJpaRepository.java
+++ b/src/test/java/org/mju_likelion/festival/announcement/domain/repository/AnnouncementJpaRepository.java
@@ -1,0 +1,13 @@
+package org.mju_likelion.festival.announcement.domain.repository;
+
+import java.util.List;
+import java.util.UUID;
+import org.mju_likelion.festival.announcement.domain.Announcement;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AnnouncementJpaRepository extends JpaRepository<Announcement, UUID> {
+
+  List<Announcement> findByWriterId(final UUID writerId);
+}

--- a/src/test/java/org/mju_likelion/festival/announcement/service/AnnouncementServiceTest.java
+++ b/src/test/java/org/mju_likelion/festival/announcement/service/AnnouncementServiceTest.java
@@ -35,20 +35,14 @@ public class AnnouncementServiceTest {
 
   @BeforeEach
   void setUp() {
-    studentCouncilAdmin = Admin.builder()
-        .loginId("student_council")
-        .password("student_council_password")
-        .name("학생회")
-        .role(AdminRole.STUDENT_COUNCIL)
-        .build();
-    adminJpaRepository.save(studentCouncilAdmin);
+    studentCouncilAdmin = adminJpaRepository.findByRole(AdminRole.STUDENT_COUNCIL)
+        .orElseThrow();
   }
 
   @AfterEach
   void tearDown() {
     announcementJpaRepository.deleteAll(
         announcementJpaRepository.findByWriterId(studentCouncilAdmin.getId()));
-    adminJpaRepository.delete(studentCouncilAdmin);
   }
 
   @Test

--- a/src/test/java/org/mju_likelion/festival/booth/domain/repository/BoothUserJpaRepository.java
+++ b/src/test/java/org/mju_likelion/festival/booth/domain/repository/BoothUserJpaRepository.java
@@ -1,0 +1,15 @@
+package org.mju_likelion.festival.booth.domain.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.mju_likelion.festival.booth.domain.Booth;
+import org.mju_likelion.festival.booth.domain.BoothUser;
+import org.mju_likelion.festival.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoothUserJpaRepository extends JpaRepository<BoothUser, UUID> {
+
+  Optional<BoothUser> findByUserAndBooth(final User user, final Booth booth);
+}

--- a/src/test/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemJpaRepository.java
+++ b/src/test/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemJpaRepository.java
@@ -1,0 +1,13 @@
+package org.mju_likelion.festival.lost_item.domain.repository;
+
+import java.util.List;
+import java.util.UUID;
+import org.mju_likelion.festival.lost_item.domain.LostItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LostItemJpaRepository extends JpaRepository<LostItem, UUID> {
+  
+  List<LostItem> findByWriterId(final UUID writerId);
+}

--- a/src/test/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemQueryRepositoryTest.java
+++ b/src/test/java/org/mju_likelion/festival/lost_item/domain/repository/LostItemQueryRepositoryTest.java
@@ -3,10 +3,12 @@ package org.mju_likelion.festival.lost_item.domain.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.IntStream;
 import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,6 +48,18 @@ public class LostItemQueryRepositoryTest {
     lostItemQueryRepository = new LostItemQueryRepository(
         new NamedParameterJdbcTemplate(dataSource));
     totalLostItemNum = (int) lostItemJpaRepository.count();
+    Admin admin = adminJpaRepository.findByRole(AdminRole.STUDENT_COUNCIL).orElseThrow();
+    List<LostItem> lostItems = new ArrayList<>();
+    for (int i = 0; i < 40; i++) {
+      LostItem lostItem = new LostItem("분실물 제목" + i, "분실물 내용" + i, new Image("asdf"), admin);
+      lostItems.add(lostItem);
+    }
+    lostItemJpaRepository.saveAll(lostItems);
+  }
+
+  @AfterEach
+  void tearDown() {
+    lostItemJpaRepository.deleteAll();
   }
 
   @DisplayName("분실물 간단 정보 List 조회 - 페이지네이션 ( 생성 시간 오름차순 )")
@@ -103,7 +117,7 @@ public class LostItemQueryRepositoryTest {
     String keyword = "지갑";
     int pageSize = 1;
     int totalPages = 1;
-    Admin admin = new Admin("lost_item_admin", "1234", "분실물 관리자", AdminRole.STUDENT_COUNCIL);
+    Admin admin = adminJpaRepository.findByRole(AdminRole.STUDENT_COUNCIL).orElseThrow();
     adminJpaRepository.saveAndFlush(admin);
     LostItem lostItem = new LostItem("지갑 발견", "발견했습니다.", new Image("asdf"), admin);
     lostItemJpaRepository.saveAndFlush(lostItem);
@@ -135,7 +149,7 @@ public class LostItemQueryRepositoryTest {
     String keyword = "지갑";
     int pageSize = 1;
     int totalPages = 1;
-    Admin admin = new Admin("lost_item_admin", "1234", "분실물 관리자", AdminRole.STUDENT_COUNCIL);
+    Admin admin = adminJpaRepository.findByRole(AdminRole.STUDENT_COUNCIL).orElseThrow();
     adminJpaRepository.saveAndFlush(admin);
     LostItem lostItem = new LostItem("발견", "지갑 발견했습니다.", new Image("asdf"), admin);
     lostItemJpaRepository.saveAndFlush(lostItem);

--- a/src/test/java/org/mju_likelion/festival/lost_item/service/LostItemServiceTest.java
+++ b/src/test/java/org/mju_likelion/festival/lost_item/service/LostItemServiceTest.java
@@ -35,20 +35,14 @@ public class LostItemServiceTest {
 
   @BeforeEach
   void setUp() {
-    studentCouncilAdmin = Admin.builder()
-        .loginId("student_council")
-        .password("student_council_password")
-        .name("학생회")
-        .role(AdminRole.STUDENT_COUNCIL)
-        .build();
-    adminJpaRepository.save(studentCouncilAdmin);
+    studentCouncilAdmin = adminJpaRepository.findByRole(AdminRole.STUDENT_COUNCIL)
+        .orElseThrow();
   }
 
   @AfterEach
   void tearDown() {
     lostItemJpaRepository.deleteAll(
         lostItemJpaRepository.findByWriterId(studentCouncilAdmin.getId()));
-    adminJpaRepository.delete(studentCouncilAdmin);
   }
 
   @DisplayName("분실물을 생성한다.")


### PR DESCRIPTION
## Description

## Changes
### Lombok 의 @ToString 을 사용하도록
- [x] Admin
- [x] Announcement
- [x] Booth
- [x] BoothUser
- [x] BoothUsers
- [x] BaseEntity
- [x] Image
- [x] LostItem
- [x] Term
- [x] TermUser
- [x] User
## Additional context
Closes #120 