### PR TITLE
Feature/#122 모든 Entity 가 equals 와 hashCode 를 재정의하도록 변경

### DIFF
--- a/src/main/java/org/mju_likelion/festival/admin/domain/Admin.java
+++ b/src/main/java/org/mju_likelion/festival/admin/domain/Admin.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Transient;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,4 +37,20 @@ public class Admin extends BaseEntity {
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   private AdminRole role;
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Admin that)) {
+      return false;
+    }
+    return Objects.equals(loginId, that.loginId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(loginId);
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/admin/domain/Admin.java
+++ b/src/main/java/org/mju_likelion/festival/admin/domain/Admin.java
@@ -46,7 +46,7 @@ public class Admin extends BaseEntity {
     if (!(o instanceof Admin that)) {
       return false;
     }
-    return Objects.equals(loginId, that.loginId);
+    return Objects.equals(loginId, that.getLoginId());
   }
 
   @Override

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/Announcement.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/Announcement.java
@@ -99,8 +99,8 @@ public class Announcement extends BaseEntity {
     if (!(o instanceof Announcement that)) {
       return false;
     }
-    return Objects.equals(title, that.title) &&
-        Objects.equals(content, that.content);
+    return Objects.equals(title, that.getTitle()) &&
+        Objects.equals(content, that.getContent());
   }
 
   @Override

--- a/src/main/java/org/mju_likelion/festival/announcement/domain/Announcement.java
+++ b/src/main/java/org/mju_likelion/festival/announcement/domain/Announcement.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Transient;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -88,5 +89,22 @@ public class Announcement extends BaseEntity {
     if (StringUtil.isBlankOrLargerThan(content, CONTENT_LENGTH)) {
       throw new BadRequestException(INVALID_ANNOUNCEMENT_CONTENT_LENGTH_ERROR);
     }
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Announcement that)) {
+      return false;
+    }
+    return Objects.equals(title, that.title) &&
+        Objects.equals(content, that.content);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(title, content);
   }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
@@ -11,6 +11,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Transient;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -131,5 +132,21 @@ public class Booth extends BaseEntity {
     if (StringUtil.isBlankOrLargerThan(location, LOCATION_LENGTH)) {
       throw new BadRequestException(INVALID_BOOTH_LOCATION_LENGTH_ERROR);
     }
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Booth that)) {
+      return false;
+    }
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
   }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
@@ -142,7 +142,7 @@ public class Booth extends BaseEntity {
     if (!(o instanceof Booth that)) {
       return false;
     }
-    return Objects.equals(name, that.name);
+    return Objects.equals(name, that.getName());
   }
 
   @Override

--- a/src/main/java/org/mju_likelion/festival/booth/domain/BoothUser.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/BoothUser.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -39,5 +40,21 @@ public class BoothUser extends BaseEntity {
    */
   public boolean isSameUserAndBooth(final User user, final Booth booth) {
     return this.user.equals(user) && this.booth.equals(booth);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BoothUser that)) {
+      return false;
+    }
+    return Objects.equals(booth, that.booth) && Objects.equals(user, that.user);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(booth, user);
   }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/domain/BoothUser.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/BoothUser.java
@@ -50,7 +50,7 @@ public class BoothUser extends BaseEntity {
     if (!(o instanceof BoothUser that)) {
       return false;
     }
-    return Objects.equals(booth, that.booth) && Objects.equals(user, that.user);
+    return Objects.equals(booth, that.getBooth()) && Objects.equals(user, that.getUser());
   }
 
   @Override

--- a/src/main/java/org/mju_likelion/festival/image/domain/Image.java
+++ b/src/main/java/org/mju_likelion/festival/image/domain/Image.java
@@ -45,7 +45,7 @@ public class Image extends BaseEntity {
     if (!(o instanceof Image that)) {
       return false;
     }
-    return Objects.equals(url, that.url);
+    return Objects.equals(url, that.getUrl());
   }
 
   @Override

--- a/src/main/java/org/mju_likelion/festival/image/domain/Image.java
+++ b/src/main/java/org/mju_likelion/festival/image/domain/Image.java
@@ -5,6 +5,7 @@ import static org.mju_likelion.festival.common.exception.type.ErrorType.INVALID_
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Transient;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,5 +35,21 @@ public class Image extends BaseEntity {
     if (StringUtil.isBlankOrLargerThan(url, URL_LENGTH)) {
       throw new BadRequestException(INVALID_IMAGE_URL_LENGTH_ERROR);
     }
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Image that)) {
+      return false;
+    }
+    return Objects.equals(url, that.url);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(url);
   }
 }

--- a/src/main/java/org/mju_likelion/festival/lost_item/domain/LostItem.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/domain/LostItem.java
@@ -134,8 +134,8 @@ public class LostItem extends BaseEntity {
     if (!(o instanceof LostItem that)) {
       return false;
     }
-    return Objects.equals(title, that.title) &&
-        Objects.equals(content, that.content);
+    return Objects.equals(title, that.getTitle()) &&
+        Objects.equals(content, that.getContent());
   }
 
   @Override

--- a/src/main/java/org/mju_likelion/festival/lost_item/domain/LostItem.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/domain/LostItem.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Transient;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -123,5 +124,22 @@ public class LostItem extends BaseEntity {
     if (writer == null) {
       throw new BadRequestException(ErrorType.LOST_ITEM_WRITER_MISSING_ERROR);
     }
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof LostItem that)) {
+      return false;
+    }
+    return Objects.equals(title, that.title) &&
+        Objects.equals(content, that.content);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(title, content);
   }
 }

--- a/src/main/java/org/mju_likelion/festival/term/domain/Term.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/Term.java
@@ -27,22 +27,22 @@ public class Term extends BaseEntity {
   @Column(nullable = false, length = CONTENT_LENGTH)
   private String content;
 
-  @Column(nullable = false)
+  @Column(unique = true, nullable = false)
   private Short sequence;
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof Term term)) {
+    if (!(o instanceof Term that)) {
       return false;
     }
-    return this.id.equals(term.id);
+    return Objects.equals(sequence, that.sequence);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id);
+    return Objects.hash(sequence);
   }
 }

--- a/src/main/java/org/mju_likelion/festival/term/domain/Term.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/Term.java
@@ -38,7 +38,7 @@ public class Term extends BaseEntity {
     if (!(o instanceof Term that)) {
       return false;
     }
-    return Objects.equals(sequence, that.sequence);
+    return Objects.equals(sequence, that.getSequence());
   }
 
   @Override

--- a/src/main/java/org/mju_likelion/festival/term/domain/TermUser.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/TermUser.java
@@ -39,7 +39,7 @@ public class TermUser extends BaseEntity {
     if (!(o instanceof TermUser that)) {
       return false;
     }
-    return Objects.equals(user, that.user) && Objects.equals(term, that.term);
+    return Objects.equals(user, that.getUser()) && Objects.equals(term, that.getTerm());
   }
 
   @Override

--- a/src/main/java/org/mju_likelion/festival/term/domain/TermUser.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/TermUser.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,18 +32,18 @@ public class TermUser extends BaseEntity {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof TermUser termUser)) {
+    if (!(o instanceof TermUser that)) {
       return false;
     }
-    return user.equals(termUser.user) && term.equals(termUser.term);
+    return Objects.equals(user, that.user) && Objects.equals(term, that.term);
   }
 
   @Override
   public int hashCode() {
-    return user.hashCode() + term.hashCode();
+    return Objects.hash(user, term);
   }
 }

--- a/src/main/java/org/mju_likelion/festival/user/domain/User.java
+++ b/src/main/java/org/mju_likelion/festival/user/domain/User.java
@@ -48,18 +48,18 @@ public class User extends BaseEntity {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof User user)) {
+    if (!(o instanceof User that)) {
       return false;
     }
-    return this.id.equals(user.id);
+    return Objects.equals(studentId, that.studentId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.id);
+    return Objects.hash(studentId);
   }
 }

--- a/src/main/java/org/mju_likelion/festival/user/domain/User.java
+++ b/src/main/java/org/mju_likelion/festival/user/domain/User.java
@@ -55,7 +55,7 @@ public class User extends BaseEntity {
     if (!(o instanceof User that)) {
       return false;
     }
-    return Objects.equals(studentId, that.studentId);
+    return Objects.equals(studentId, that.getStudentId());
   }
 
   @Override


### PR DESCRIPTION
## Description
모든 Entity 가 equals 와 hashCode 를 재정의하도록 변경

새로 생성된 Entity 의 경우, id 를 할당받지 못 했을 수 있으므로, 비즈니스 키를 사용해 equals와 hashCode를 재정의
## Changes
### Entity
- [x] Admin
- [x] Announcement
- [x] User
- [x] LostItem
- [x] Term
- [x] TermUser
- [x] Image
- [x] Booth
- [x] BoothUser

## Additional context
Closes #122 