### PR TITLE
Feature/#131 날짜 Filtering 구현

### DIFF
--- a/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/AbstractAuthenticationInterceptor.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/AbstractAuthenticationInterceptor.java
@@ -11,10 +11,10 @@ import org.mju_likelion.festival.auth.util.jwt.JwtUtil;
 import org.mju_likelion.festival.auth.util.jwt.Payload;
 import org.mju_likelion.festival.common.authentication.AuthenticationContext;
 import org.mju_likelion.festival.common.authentication.AuthorizationExtractor;
-import org.mju_likelion.festival.common.config.RequestMatcher;
 import org.mju_likelion.festival.common.exception.ForbiddenException;
 import org.mju_likelion.festival.common.exception.UnauthorizedException;
 import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.mju_likelion.festival.common.util.request_matcher.RequestMatcher;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 public abstract class AbstractAuthenticationInterceptor implements HandlerInterceptor {

--- a/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/BoothAdminAuthenticationInterceptor.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/BoothAdminAuthenticationInterceptor.java
@@ -9,8 +9,8 @@ import org.mju_likelion.festival.auth.util.jwt.AuthenticationRole;
 import org.mju_likelion.festival.auth.util.jwt.JwtUtil;
 import org.mju_likelion.festival.auth.util.jwt.Payload;
 import org.mju_likelion.festival.common.authentication.AuthenticationContext;
-import org.mju_likelion.festival.common.config.RequestMatcher;
 import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.mju_likelion.festival.common.util.request_matcher.RequestMatcher;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/StudentCouncilAuthenticationInterceptor.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/interceptor/StudentCouncilAuthenticationInterceptor.java
@@ -9,8 +9,8 @@ import org.mju_likelion.festival.auth.util.jwt.AuthenticationRole;
 import org.mju_likelion.festival.auth.util.jwt.JwtUtil;
 import org.mju_likelion.festival.auth.util.jwt.Payload;
 import org.mju_likelion.festival.common.authentication.AuthenticationContext;
-import org.mju_likelion.festival.common.config.RequestMatcher;
 import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.mju_likelion.festival.common.util.request_matcher.RequestMatcher;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/org/mju_likelion/festival/common/config/FilterConfig.java
+++ b/src/main/java/org/mju_likelion/festival/common/config/FilterConfig.java
@@ -1,0 +1,38 @@
+package org.mju_likelion.festival.common.config;
+
+import org.mju_likelion.festival.common.filter.FrontFilter;
+import org.mju_likelion.festival.common.filter.date_restriction.DateRestrictionFilter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+  @Value("${application.service.end.date}")
+  private String endDateString;
+  @Value("${application.service.start.date}")
+  private String startDateString;
+
+  @Bean
+  public FilterRegistrationBean<FrontFilter> frontFilterFilterRegistrationBean() {
+    FilterRegistrationBean<FrontFilter> registrationBean = new FilterRegistrationBean<>();
+    registrationBean.setFilter(new FrontFilter());
+    registrationBean.addUrlPatterns("/*");
+    registrationBean.setOrder(0);
+
+    return registrationBean;
+  }
+
+  @Bean
+  public FilterRegistrationBean<DateRestrictionFilter> dateRestrictedFilterFilterRegistrationBean() {
+    FilterRegistrationBean<DateRestrictionFilter> registrationBean = new FilterRegistrationBean<>();
+    registrationBean.setFilter(new DateRestrictionFilter());
+    registrationBean.addUrlPatterns("/*");
+    registrationBean.addInitParameter("startDateString", startDateString);
+    registrationBean.addInitParameter("endDateString", endDateString);
+
+    return registrationBean;
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/exception/ServiceUnavailableException.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/ServiceUnavailableException.java
@@ -1,0 +1,15 @@
+package org.mju_likelion.festival.common.exception;
+
+import org.mju_likelion.festival.common.exception.type.ErrorType;
+import org.springframework.http.HttpStatus;
+
+public class ServiceUnavailableException extends CustomException {
+
+  public ServiceUnavailableException(final ErrorType errorType) {
+    super(errorType, HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+  public ServiceUnavailableException(final ErrorType errorType, final String detail) {
+    super(errorType, detail, HttpStatus.SERVICE_UNAVAILABLE);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
@@ -71,6 +71,8 @@ public enum ErrorType {
   RSA_KEY_ERROR(50007, "RSA 키 처리 중 오류가 발생했습니다."),
   REDIS_ERROR(50008, "Redis 에러가 발생했습니다."),
 
+  DATE_RESTRICTED_ERROR(50300, "운영 기간이 아닙니다."),
+
   UNEXPECTED_ERROR(99999, "예기치 않은 오류가 발생했습니다.");
 
   private final int code;

--- a/src/main/java/org/mju_likelion/festival/common/filter/ErrorResponseHandler.java
+++ b/src/main/java/org/mju_likelion/festival/common/filter/ErrorResponseHandler.java
@@ -1,0 +1,31 @@
+package org.mju_likelion.festival.common.filter;
+
+import static org.apache.commons.codec.CharEncoding.UTF_8;
+import static org.apache.http.entity.ContentType.APPLICATION_JSON;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.mju_likelion.festival.common.exception.CustomException;
+import org.mju_likelion.festival.common.exception.dto.ErrorResponse;
+
+public class ErrorResponseHandler {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  public static void writeErrorResponse(
+      final ServletResponse response,
+      final CustomException customException)
+      throws IOException {
+
+    ErrorResponse errorResponse = ErrorResponse.res(customException);
+
+    HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+    httpServletResponse.setStatus(customException.getHttpStatus().value());
+    httpServletResponse.setContentType(APPLICATION_JSON.getMimeType());
+    httpServletResponse.setCharacterEncoding(UTF_8);
+    httpServletResponse.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+  }
+}
+

--- a/src/main/java/org/mju_likelion/festival/common/filter/FrontFilter.java
+++ b/src/main/java/org/mju_likelion/festival/common/filter/FrontFilter.java
@@ -1,0 +1,27 @@
+package org.mju_likelion.festival.common.filter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import java.io.IOException;
+import org.mju_likelion.festival.common.exception.CustomException;
+
+public class FrontFilter implements Filter {
+
+  @Override
+  public void doFilter(
+      final ServletRequest request,
+      final ServletResponse response,
+      final FilterChain chain)
+      throws IOException, ServletException {
+
+    try {
+      chain.doFilter(request, response);
+    } catch (CustomException customException) {
+      ErrorResponseHandler.writeErrorResponse(response, customException);
+      response.getWriter().flush();
+    }
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/filter/date_restriction/DateRestrictionFilter.java
+++ b/src/main/java/org/mju_likelion/festival/common/filter/date_restriction/DateRestrictionFilter.java
@@ -1,0 +1,42 @@
+package org.mju_likelion.festival.common.filter.date_restriction;
+
+import static org.mju_likelion.festival.common.exception.type.ErrorType.DATE_RESTRICTED_ERROR;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import java.io.IOException;
+import java.time.LocalDate;
+import org.mju_likelion.festival.common.exception.ServiceUnavailableException;
+
+public class DateRestrictionFilter implements Filter {
+
+  private LocalDate startDate;
+  private LocalDate endDate;
+
+  @Override
+  public void init(FilterConfig filterConfig) {
+    String startDateString = filterConfig.getInitParameter("startDateString");
+    String endDateString = filterConfig.getInitParameter("endDateString");
+
+    startDate = LocalDate.parse(startDateString);
+    endDate = LocalDate.parse(endDateString);
+  }
+
+  @Override
+  public void doFilter(
+      final ServletRequest request,
+      final ServletResponse response,
+      final FilterChain chain) throws IOException, ServletException {
+
+    LocalDate currentDate = LocalDate.now();
+
+    if (currentDate.isBefore(startDate) || currentDate.isAfter(endDate)) {
+      throw new ServiceUnavailableException(DATE_RESTRICTED_ERROR);
+    }
+    chain.doFilter(request, response);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/util/request_matcher/RequestMatcher.java
+++ b/src/main/java/org/mju_likelion/festival/common/util/request_matcher/RequestMatcher.java
@@ -1,4 +1,4 @@
-package org.mju_likelion.festival.common.config;
+package org.mju_likelion.festival.common.util.request_matcher;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;


### PR DESCRIPTION
## Description
날짜 Filtering 구현

어떤 URI 에 적용할지는 추후에 결정
## Changes
### 날짜 제한 Filter
- [x] DateRestrictionFilter
### 최상단 Filter
- [x] FrontFilter
### Filter 설정
- [x] FilterConfig

## Additional context
Filter 적용 시 URI 패턴 관련 문제 발견
/booths/{id}/ownership , /booths/{id} 를 구분할 방법이 없음

-> 구현해놓은 RequestMatcher 를 사용할 예정

Closes #131 