### PR TITLE
Feature/#145 application.properties 분리

### DIFF
--- a/.github/workflows/ci-cd-develop.yml
+++ b/.github/workflows/ci-cd-develop.yml
@@ -31,16 +31,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      # 2. application.properties 파일 생성
-      - name: make application.properties
-        run: |
-          mkdir -p ./src/main/resources
-          cd ./src/main/resources
-          touch ./application.properties
-          echo "${{ secrets.DEV_PROPERTIES }}" > ./application.properties
-        shell: bash
-
-      # 2-1. test 용 application.properties 파일 생성
+      # 2. test 용 application.properties 파일 생성
       - name: make application.properties for test
         run: |
           mkdir -p ./src/test/resources

--- a/.github/workflows/ci-cd-develop.yml
+++ b/.github/workflows/ci-cd-develop.yml
@@ -40,11 +40,15 @@ jobs:
           echo "${{ secrets.DEV_TEST_PROPERTIES }}" > ./application.properties
         shell: bash
 
+      # 2-1. Gradle Test 를 실행한다
+      - name: Test with Gradle
+        run: ./gradlew --info test
+
       # 3. Spring Boot 애플리케이션 빌드
       - name: Build with Gradle
         uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
         with:
-          arguments: clean bootJar
+          arguments: clean bootJar -x test
 
       # 4. Docker 이미지 빌드
       - name: docker image build

--- a/.github/workflows/ci-cd-develop.yml
+++ b/.github/workflows/ci-cd-develop.yml
@@ -66,6 +66,14 @@ jobs:
     needs: build-docker-image
     runs-on: ubuntu-latest
     steps:
+      - name: set application-dev.properties
+        run: |
+          mkdir -p ~/properties/dev
+          cd ~/properties/dev
+          touch ./application-dev.properties
+          echo "${{ secrets.DEV_PROPERTIES }}" > ./application-dev.properties
+        shell: bash
+
       - name: ssh connect & production
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/ci-cd-develop.yml
+++ b/.github/workflows/ci-cd-develop.yml
@@ -85,7 +85,7 @@ jobs:
             sudo docker pull ${{secrets.DOCKERHUB_USERNAME}}/${{secrets.DEV_DOCKERHUB_IMAGE}}
             sudo docker ps -q | xargs -r sudo docker stop
             sudo docker ps -aq | xargs -r sudo docker rm
-            sudo docker run --name ${{secrets.DEV_DOCKERHUB_IMAGE}} --rm -d -p 8080:8080 -v ~/logs:/logs ${{secrets.DOCKERHUB_USERNAME}}/${{secrets.DEV_DOCKERHUB_IMAGE}}
+            sudo docker run --name ${{secrets.DEV_DOCKERHUB_IMAGE}} --rm -d -p 8080:8080 -v ~/logs:/logs -v ~/properties:/properties -e SPRING_PROFILES_ACTIVE=dev -e SPRING_CONFIG_LOCATION=/properties/application-dev.properties ${{secrets.DOCKERHUB_USERNAME}}/${{secrets.DEV_DOCKERHUB_IMAGE}}
             sudo docker system prune -f
             
             

--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,5 @@ hs_err_pid*
 replay_pid*
 
 # application.properties
-**/main/resources/application.properties
-**/test/resources/application.properties
+**/main/resources/*
+**/test/resources/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM openjdk:17-jdk
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 ENV JAVA_OPTS="-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true"
-ENTRYPOINT ["java", "-Dspring.profiles.active=docker", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=${SPRING_PROFILES_ACTIVE:-default}", "-Dspring.config.location=${SPRING_CONFIG_LOCATION:-classpath:/application.properties}", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]


### PR DESCRIPTION
## Description

## Changes
### 모든 application.properties 를 올리지 않도록
- [x] .gitignore
### ci-cd dev 스크립트 수정
- [x] applicaiton-dev.properties 를 인스턴스 내부에 만들도록
- [x] jar 파일 빌드 시 application.properties 를 주입하지 않도록
- [x] 컨테이너 실행 시 환경 변수를 주입하도록
- [x] 테스트 실행을 독립적으로 분리
- [x] 빌드 시 테스트를 제외하고 빌드하도록
### Dockerfile
- [x] ENTRYPOINT 에서 환경 변수를 사용하도록

## Additional context
동작 확인 후 이슈를 닫을 예정