### PR TITLE
Feature/#161 부스 전체 조회 시 소속 필터링 추가

### DIFF
--- a/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
+++ b/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
@@ -47,10 +47,11 @@ public class BoothController {
 
   @GetMapping(GET_ALL_BOOTHS)
   public ResponseEntity<SimpleBoothsResponse> getBooths(
+      @RequestParam(name = "department_id") final UUID departmentId,
       @RequestParam @PageNumber final int page,
       @RequestParam @PageSize final int size) {
 
-    return ResponseEntity.ok(boothQueryService.getBooths(page, size));
+    return ResponseEntity.ok(boothQueryService.getBooths(departmentId, page, size));
   }
 
   @GetMapping(GET_BOOTH)

--- a/src/main/java/org/mju_likelion/festival/booth/domain/repository/BoothQueryRepository.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/repository/BoothQueryRepository.java
@@ -59,20 +59,27 @@ public class BoothQueryRepository {
   /**
    * 페이지네이션을 적용하여 부스 간단 정보 List 조회.
    *
-   * @param page 페이지
-   * @param size 크기
+   * @param departmentId 부스 소속 ID
+   * @param page         페이지
+   * @param size         크기
    * @return 부스 간단 정보 List
    */
-  public List<SimpleBooth> findOrderedSimpleBoothsWithPagination(final int page, final int size) {
+  public List<SimpleBooth> findOrderedSimpleBoothsByDepartmentWithPagination(
+      final UUID departmentId,
+      final int page,
+      final int size) {
+
     String sql =
         "SELECT HEX(b.id) AS boothId, b.name AS boothName, b.description AS boothDescription, "
             + "i.url AS imageUrl "
             + "FROM booth b "
             + "LEFT JOIN image i ON b.image_id = i.id "
+            + "WHERE b.department_id = UNHEX(:departmentId) "
             + "ORDER BY b.sequence ASC "
             + "LIMIT :limit OFFSET :offset";
 
     MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("departmentId", uuidToHex(departmentId))
         .addValue("limit", size)
         .addValue("offset", page * size);
 
@@ -80,15 +87,17 @@ public class BoothQueryRepository {
   }
 
   /**
-   * 페이지네이션 시 부스 간단 정보 List 총 페이지 수 조회.
+   * 페이지네이션 시 부스 소속 ID 에 해당하는 부스들의 총 페이지 수 조회.
    *
-   * @param size 크기
+   * @param departmentId 부스 소속 ID
+   * @param size         크기
    * @return 총 페이지 수
    */
-  public int findTotalPage(final int size) {
-    String sql = "SELECT CEIL(COUNT(*) / :size) FROM booth";
+  public int findTotalPage(final UUID departmentId, final int size) {
+    String sql = "SELECT CEIL(COUNT(*) / :size) FROM booth b WHERE b.department_id = UNHEX(:departmentId)";
 
     MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("departmentId", uuidToHex(departmentId))
         .addValue("size", size);
 
     return jdbcTemplate.queryForObject(sql, params, Integer.class);

--- a/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
@@ -1,5 +1,6 @@
 package org.mju_likelion.festival.booth.service;
 
+import static org.mju_likelion.festival.common.exception.type.ErrorType.BOOTH_DEPARTMENT_NOT_FOUND_ERROR;
 import static org.mju_likelion.festival.common.exception.type.ErrorType.BOOTH_NOT_FOUND_ERROR;
 import static org.mju_likelion.festival.common.exception.type.ErrorType.NOT_BOOTH_OWNER_ERROR;
 import static org.mju_likelion.festival.common.exception.type.ErrorType.PAGE_OUT_OF_BOUND_ERROR;
@@ -43,6 +44,8 @@ public class BoothQueryService {
   }
 
   public SimpleBoothsResponse getBooths(final UUID departmentId, final int page, final int size) {
+    validateBoothDepartment(departmentId);
+    
     int totalPage = boothQueryRepository.findTotalPage(departmentId, size);
 
     validatePage(page, totalPage);
@@ -76,6 +79,12 @@ public class BoothQueryService {
     validateBoothAdminOwner(admin, booth);
 
     return new BoothQrResponse(boothQrManager.generateBoothQr(boothId));
+  }
+
+  private void validateBoothDepartment(final UUID departmentId) {
+    if (!boothDepartmentJpaRepository.existsById(departmentId)) {
+      throw new NotFoundException(BOOTH_DEPARTMENT_NOT_FOUND_ERROR);
+    }
   }
 
   public void validateBoothAdminOwner(final Admin admin, final Booth booth) {

--- a/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
@@ -42,13 +42,13 @@ public class BoothQueryService {
         .toList();
   }
 
-  public SimpleBoothsResponse getBooths(final int page, final int size) {
-    int totalPage = boothQueryRepository.findTotalPage(size);
+  public SimpleBoothsResponse getBooths(final UUID departmentId, final int page, final int size) {
+    int totalPage = boothQueryRepository.findTotalPage(departmentId, size);
 
     validatePage(page, totalPage);
 
-    List<SimpleBooth> simpleBooths = boothQueryRepository.findOrderedSimpleBoothsWithPagination(
-        page, size);
+    List<SimpleBooth> simpleBooths = boothQueryRepository.findOrderedSimpleBoothsByDepartmentWithPagination(
+        departmentId, page, size);
 
     return SimpleBoothsResponse.from(simpleBooths, totalPage);
   }

--- a/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
+++ b/src/main/java/org/mju_likelion/festival/common/exception/type/ErrorType.java
@@ -51,6 +51,7 @@ public enum ErrorType {
   PAGE_OUT_OF_BOUND_ERROR(40406, "페이지 범위를 벗어났습니다."),
   ANNOUNCEMENT_NOT_FOUND_ERROR(40407, "존재하지 않는 공지사항입니다."),
   LOST_ITEM_NOT_FOUND_ERROR(40408, "존재하지 않는 분실물입니다."),
+  BOOTH_DEPARTMENT_NOT_FOUND_ERROR(40409, "존재하지 않는 부스 소속입니다."),
 
   METHOD_NOT_ALLOWED_ERROR(40500, "허용되지 않은 HTTP 메소드입니다."),
 

--- a/src/test/java/org/mju_likelion/festival/booth/domain/repository/BoothJpaRepository.java
+++ b/src/test/java/org/mju_likelion/festival/booth/domain/repository/BoothJpaRepository.java
@@ -1,0 +1,14 @@
+package org.mju_likelion.festival.booth.domain.repository;
+
+import java.util.UUID;
+import org.mju_likelion.festival.booth.domain.Booth;
+import org.mju_likelion.festival.booth.domain.BoothDepartment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoothJpaRepository extends JpaRepository<Booth, UUID> {
+
+  long countByBoothInfo_Department(BoothDepartment department);
+
+}

--- a/src/test/java/org/mju_likelion/festival/booth/domain/repository/BoothQueryRepositoryTest.java
+++ b/src/test/java/org/mju_likelion/festival/booth/domain/repository/BoothQueryRepositoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mju_likelion.festival.booth.domain.Booth;
+import org.mju_likelion.festival.booth.domain.BoothDepartment;
 import org.mju_likelion.festival.booth.domain.BoothDetail;
 import org.mju_likelion.festival.booth.domain.SimpleBooth;
 import org.mju_likelion.festival.common.annotation.ApplicationTest;
@@ -26,16 +27,21 @@ public class BoothQueryRepositoryTest {
   private BoothJpaRepository boothJpaRepository;
 
   @Autowired
+  private BoothDepartmentJpaRepository boothDepartmentJpaRepository;
+
+  @Autowired
   private DataSource dataSource;
 
   private BoothQueryRepository boothQueryRepository;
 
+  private BoothDepartment department;
   private int totalBoothNum;
 
   @BeforeEach
   void setUp() {
+    department = boothDepartmentJpaRepository.findAll().get(0);
     boothQueryRepository = new BoothQueryRepository(new NamedParameterJdbcTemplate(dataSource));
-    totalBoothNum = (int) boothJpaRepository.count();
+    totalBoothNum = (int) boothJpaRepository.countByBoothInfo_Department(department);
   }
 
   @DisplayName("부스 간단 정보 List 조회 - 페이지네이션")
@@ -47,8 +53,8 @@ public class BoothQueryRepositoryTest {
 
     // when & then
     IntStream.range(0, totalPages).forEach(page -> {
-      List<SimpleBooth> pageContent = boothQueryRepository.findOrderedSimpleBoothsWithPagination(
-          page, pageSize);
+      List<SimpleBooth> pageContent = boothQueryRepository.findOrderedSimpleBoothsByDepartmentWithPagination(
+          department.getId(), page, pageSize);
 
       int expectedSize = calculateExpectedSize(page, pageSize, totalBoothNum);
 

--- a/src/test/java/org/mju_likelion/festival/booth/service/BoothQueryServiceTest.java
+++ b/src/test/java/org/mju_likelion/festival/booth/service/BoothQueryServiceTest.java
@@ -9,8 +9,9 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mju_likelion.festival.admin.domain.Admin;
-import org.mju_likelion.festival.admin.domain.repository.AdminJpaRepository;
 import org.mju_likelion.festival.booth.domain.Booth;
+import org.mju_likelion.festival.booth.domain.BoothDepartment;
+import org.mju_likelion.festival.booth.domain.repository.BoothDepartmentJpaRepository;
 import org.mju_likelion.festival.booth.domain.repository.BoothJpaRepository;
 import org.mju_likelion.festival.booth.dto.response.BoothDetailResponse;
 import org.mju_likelion.festival.booth.dto.response.SimpleBoothsResponse;
@@ -31,7 +32,7 @@ public class BoothQueryServiceTest {
   @Autowired
   private BoothJpaRepository boothJpaRepository;
   @Autowired
-  private AdminJpaRepository adminJpaRepository;
+  private BoothDepartmentJpaRepository boothDepartmentJpaRepository;
   @MockBean
   private BoothQrManagerContext boothQrManagerContext;
   @Autowired
@@ -43,11 +44,12 @@ public class BoothQueryServiceTest {
   @Test
   public void testGetBooths() {
     // given
+    BoothDepartment department = boothDepartmentJpaRepository.findAll().get(0);
     int page = 0;
     int size = 5;
 
     // when
-    SimpleBoothsResponse booths = boothQueryService.getBooths(page, size);
+    SimpleBoothsResponse booths = boothQueryService.getBooths(department.getId(), page, size);
 
     // then
     assertThat(booths).isNotNull();


### PR DESCRIPTION
## Description
부스 전체 조회 시 소속 필터링 추가

전체 조회 시 소속을 반드시 넣어야 함
## Changes
### 부스 조회 쿼리 수정
- [x] BoothQueryRepository
### Service 수정
- [x] BoothQueryService
### Controller 수정
- [x] BoothController
### API
| URL                     | method | Usage                   | Authorization Needed |
| ------------------ | ---------| -------------------- | ------------------------ |
|          /booths?department_id={}&page={}&size={}                  |    GET           |              부스 전체 조회(페이지네이션)                |                X          |
## Additional context
Closes #161 