### PR TITLE
Feature/#171 분실물 찾음 처리 시 Request Body 역직렬화 버그 수정

### DIFF
--- a/src/main/java/org/mju_likelion/festival/lost_item/dto/request/LostItemFoundRequest.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/dto/request/LostItemFoundRequest.java
@@ -1,14 +1,14 @@
 package org.mju_likelion.festival.lost_item.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 분실물 찾음 처리 요청 DTO
  */
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 public class LostItemFoundRequest {
 
   @NotBlank(message = "수령인 정보는 필수값입니다.")

--- a/src/main/java/org/mju_likelion/festival/lost_item/dto/request/LostItemFoundRequest.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/dto/request/LostItemFoundRequest.java
@@ -1,6 +1,7 @@
 package org.mju_likelion.festival.lost_item.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
  */
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class LostItemFoundRequest {
 
   @NotBlank(message = "수령인 정보는 필수값입니다.")


### PR DESCRIPTION
## Description
분실물 찾음 처리 시 Request Body 역직렬화 버그 수정

기본 생성자가 없어 문제 발생
## Changes
### LostItemFoundRequest DTO 수정
- [x] LostItemFoundRequest

## Additional context
Closes #171 