### PR TITLE
Feature/#170 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/org/mju_likelion/festival/auth/controller/AuthController.java
+++ b/src/main/java/org/mju_likelion/festival/auth/controller/AuthController.java
@@ -3,8 +3,10 @@ package org.mju_likelion.festival.auth.controller;
 import static org.mju_likelion.festival.common.api.ApiPaths.ADMIN_LOGIN;
 import static org.mju_likelion.festival.common.api.ApiPaths.AUTH_KEY;
 import static org.mju_likelion.festival.common.api.ApiPaths.USER_LOGIN;
+import static org.mju_likelion.festival.common.api.ApiPaths.USER_WITHDRAW;
 
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.mju_likelion.festival.auth.dto.request.AdminLoginRequest;
 import org.mju_likelion.festival.auth.dto.request.UserLoginRequest;
@@ -14,7 +16,9 @@ import org.mju_likelion.festival.auth.dto.response.UserLoginResponse;
 import org.mju_likelion.festival.auth.service.AuthQueryService;
 import org.mju_likelion.festival.auth.service.AuthService;
 import org.mju_likelion.festival.auth.util.rsa_key.RsaKeyStrategy;
+import org.mju_likelion.festival.common.authentication.AuthenticationPrincipal;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -50,5 +54,12 @@ public class AuthController {
 
     return ResponseEntity.ok(
         authQueryService.adminLogin(adminLoginRequest, RsaKeyStrategy.fromString(rsaKeyStrategy)));
+  }
+
+  @DeleteMapping(USER_WITHDRAW)
+  public ResponseEntity<Void> withdrawUser(@AuthenticationPrincipal final UUID userId) {
+
+    authService.withdrawUser(userId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/org/mju_likelion/festival/auth/service/AuthService.java
+++ b/src/main/java/org/mju_likelion/festival/auth/service/AuthService.java
@@ -45,4 +45,9 @@ public class AuthService {
     String accessToken = authServiceUtil.createAccessToken(userId, AuthenticationRole.USER);
     return UserLoginResponse.of(accessToken);
   }
+
+  public void withdrawUser(final UUID userId) {
+    userQueryService.validateUserExists(userId);
+    userService.deleteById(userId);
+  }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/domain/repository/BoothUserJpaRepository.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/repository/BoothUserJpaRepository.java
@@ -1,11 +1,18 @@
 package org.mju_likelion.festival.booth.domain.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.UUID;
+import lombok.NonNull;
 import org.mju_likelion.festival.booth.domain.BoothUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoothUserJpaRepository extends JpaRepository<BoothUser, UUID> {
 
+  @Modifying
+  @Query("DELETE FROM booth_user bu WHERE bu.user.id = :userId")
+  void deleteByUserId(@NonNull @Param("userId") final UUID userId);
 }

--- a/src/main/java/org/mju_likelion/festival/booth/service/BoothUserService.java
+++ b/src/main/java/org/mju_likelion/festival/booth/service/BoothUserService.java
@@ -1,0 +1,19 @@
+package org.mju_likelion.festival.booth.service;
+
+import jakarta.transaction.Transactional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.mju_likelion.festival.booth.domain.repository.BoothUserJpaRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BoothUserService {
+
+  private final BoothUserJpaRepository boothUserJpaRepository;
+
+  public void deleteAllByUserId(final UUID userId) {
+    boothUserJpaRepository.deleteByUserId(userId);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/api/ApiPaths.java
+++ b/src/main/java/org/mju_likelion/festival/common/api/ApiPaths.java
@@ -36,6 +36,7 @@ public class ApiPaths {
   public static final String ADMIN_LOGIN = AUTH + "/admin/login";
   public static final String USER_LOGIN = AUTH + "/user/login";
   public static final String AUTH_KEY = AUTH + "/key";
+  public static final String USER_WITHDRAW = AUTH + USERS + "/withdraw";
 
   // announcement
   private static final String ANNOUNCEMENTS = "/announcements";

--- a/src/main/java/org/mju_likelion/festival/common/authentication/config/AuthenticationConfig.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/config/AuthenticationConfig.java
@@ -12,6 +12,7 @@ import static org.mju_likelion.festival.common.api.ApiPaths.POST_ANNOUNCEMENT;
 import static org.mju_likelion.festival.common.api.ApiPaths.POST_LOST_ITEM;
 import static org.mju_likelion.festival.common.api.ApiPaths.SEARCH_LOST_ITEMS;
 import static org.mju_likelion.festival.common.api.ApiPaths.UPLOAD_IMAGE;
+import static org.mju_likelion.festival.common.api.ApiPaths.USER_WITHDRAW;
 import static org.mju_likelion.festival.common.api.ApiPaths.VISIT_BOOTH;
 
 import java.util.List;
@@ -89,7 +90,8 @@ public class AuthenticationConfig {
   private void addUserAuthenticationInterceptor(final InterceptorRegistry registry) {
     registry.addInterceptor(userAuthenticationInterceptor)
         .addPathPatterns(VISIT_BOOTH)
-        .addPathPatterns(GET_MY_STAMP);
+        .addPathPatterns(GET_MY_STAMP)
+        .addPathPatterns(USER_WITHDRAW);
   }
 
   public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {

--- a/src/main/java/org/mju_likelion/festival/term/domain/repository/TermUserJpaRepository.java
+++ b/src/main/java/org/mju_likelion/festival/term/domain/repository/TermUserJpaRepository.java
@@ -1,11 +1,18 @@
 package org.mju_likelion.festival.term.domain.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.UUID;
+import lombok.NonNull;
 import org.mju_likelion.festival.term.domain.TermUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TermUserJpaRepository extends JpaRepository<TermUser, UUID> {
 
+  @Modifying
+  @Query("DELETE FROM term_user tu WHERE tu.user.id = :userId")
+  void deleteByUserId(@NonNull @Param("userId") final UUID userId);
 }

--- a/src/main/java/org/mju_likelion/festival/term/service/TermUserService.java
+++ b/src/main/java/org/mju_likelion/festival/term/service/TermUserService.java
@@ -1,0 +1,19 @@
+package org.mju_likelion.festival.term.service;
+
+import jakarta.transaction.Transactional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.mju_likelion.festival.term.domain.repository.TermUserJpaRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TermUserService {
+
+  private final TermUserJpaRepository termUserJpaRepository;
+
+  public void deleteAllByUserId(final UUID userId) {
+    termUserJpaRepository.deleteByUserId(userId);
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/user/controller/UserController.java
+++ b/src/main/java/org/mju_likelion/festival/user/controller/UserController.java
@@ -7,7 +7,6 @@ import lombok.AllArgsConstructor;
 import org.mju_likelion.festival.common.authentication.AuthenticationPrincipal;
 import org.mju_likelion.festival.user.dto.response.StampResponse;
 import org.mju_likelion.festival.user.service.UserQueryService;
-import org.mju_likelion.festival.user.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
   private final UserQueryService userQueryService;
-  private final UserService userService;
 
   @GetMapping(GET_MY_STAMP)
   public ResponseEntity<StampResponse> getMyStamp(@AuthenticationPrincipal final UUID userId) {

--- a/src/main/java/org/mju_likelion/festival/user/controller/UserController.java
+++ b/src/main/java/org/mju_likelion/festival/user/controller/UserController.java
@@ -1,7 +1,6 @@
 package org.mju_likelion.festival.user.controller;
 
 import static org.mju_likelion.festival.common.api.ApiPaths.GET_MY_STAMP;
-import static org.mju_likelion.festival.common.api.ApiPaths.USER_WITHDRAW;
 
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -10,7 +9,6 @@ import org.mju_likelion.festival.user.dto.response.StampResponse;
 import org.mju_likelion.festival.user.service.UserQueryService;
 import org.mju_likelion.festival.user.service.UserService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,12 +22,5 @@ public class UserController {
   @GetMapping(GET_MY_STAMP)
   public ResponseEntity<StampResponse> getMyStamp(@AuthenticationPrincipal final UUID userId) {
     return ResponseEntity.ok(userQueryService.getUserStampById(userId));
-  }
-
-  @DeleteMapping(USER_WITHDRAW)
-  public ResponseEntity<Void> withdrawUser(@AuthenticationPrincipal final UUID userId) {
-
-    userService.withdrawUser(userId);
-    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/org/mju_likelion/festival/user/controller/UserController.java
+++ b/src/main/java/org/mju_likelion/festival/user/controller/UserController.java
@@ -1,13 +1,16 @@
 package org.mju_likelion.festival.user.controller;
 
 import static org.mju_likelion.festival.common.api.ApiPaths.GET_MY_STAMP;
+import static org.mju_likelion.festival.common.api.ApiPaths.USER_WITHDRAW;
 
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.mju_likelion.festival.common.authentication.AuthenticationPrincipal;
 import org.mju_likelion.festival.user.dto.response.StampResponse;
 import org.mju_likelion.festival.user.service.UserQueryService;
+import org.mju_likelion.festival.user.service.UserService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,9 +19,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
   private final UserQueryService userQueryService;
+  private final UserService userService;
 
   @GetMapping(GET_MY_STAMP)
   public ResponseEntity<StampResponse> getMyStamp(@AuthenticationPrincipal final UUID userId) {
     return ResponseEntity.ok(userQueryService.getUserStampById(userId));
+  }
+
+  @DeleteMapping(USER_WITHDRAW)
+  public ResponseEntity<Void> withdrawUser(@AuthenticationPrincipal final UUID userId) {
+
+    userService.withdrawUser(userId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/org/mju_likelion/festival/user/domain/repository/UserJpaRepository.java
+++ b/src/main/java/org/mju_likelion/festival/user/domain/repository/UserJpaRepository.java
@@ -3,8 +3,10 @@ package org.mju_likelion.festival.user.domain.repository;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.NonNull;
 import org.mju_likelion.festival.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -19,4 +21,8 @@ public interface UserJpaRepository extends JpaRepository<User, UUID> {
    */
   @Query("SELECT u.id FROM user u WHERE u.studentId = :studentId")
   Optional<UUID> findIdByStudentId(@Param("studentId") final String studentId);
+
+  @Modifying
+  @Query("DELETE FROM user u WHERE u.id = :userId")
+  void deleteById(@NonNull @Param("userId") final UUID userId);
 }

--- a/src/main/java/org/mju_likelion/festival/user/service/UserService.java
+++ b/src/main/java/org/mju_likelion/festival/user/service/UserService.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.mju_likelion.festival.booth.service.BoothUserService;
 import org.mju_likelion.festival.term.domain.Term;
+import org.mju_likelion.festival.term.service.TermUserService;
 import org.mju_likelion.festival.user.domain.User;
 import org.mju_likelion.festival.user.domain.repository.UserJpaRepository;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
   private final UserJpaRepository userJpaRepository;
+  private final UserQueryService userQueryService;
+
+  private final TermUserService termUserService;
+  private final BoothUserService boothUserService;
+
+  public void withdrawUser(final UUID userId) {
+    userQueryService.validateUserExists(userId);
+    deleteUserById(userId);
+  }
 
   /**
    * 사용자가 동의한 약관을 저장하고, 사용자의 ID를 반환한다.
@@ -30,6 +41,12 @@ public class UserService {
     Optional<UUID> userId = userJpaRepository.findIdByStudentId(studentId);
 
     return userId.orElseGet(() -> saveUser(studentId, terms));
+  }
+
+  private void deleteUserById(final UUID userId) {
+    termUserService.deleteAllByUserId(userId);
+    boothUserService.deleteAllByUserId(userId);
+    userJpaRepository.deleteById(userId);
   }
 
   /**

--- a/src/main/java/org/mju_likelion/festival/user/service/UserService.java
+++ b/src/main/java/org/mju_likelion/festival/user/service/UserService.java
@@ -18,15 +18,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
   private final UserJpaRepository userJpaRepository;
-  private final UserQueryService userQueryService;
 
   private final TermUserService termUserService;
   private final BoothUserService boothUserService;
-
-  public void withdrawUser(final UUID userId) {
-    userQueryService.validateUserExists(userId);
-    deleteUserById(userId);
-  }
 
   /**
    * 사용자가 동의한 약관을 저장하고, 사용자의 ID를 반환한다.
@@ -43,7 +37,7 @@ public class UserService {
     return userId.orElseGet(() -> saveUser(studentId, terms));
   }
 
-  private void deleteUserById(final UUID userId) {
+  public void deleteById(final UUID userId) {
     termUserService.deleteAllByUserId(userId);
     boothUserService.deleteAllByUserId(userId);
     userJpaRepository.deleteById(userId);


### PR DESCRIPTION
## Description
회원 탈퇴 API 구현
## Changes
### userId 로 모든 Entity 삭제 JPA 메서드 추가
- [x] BoothUserJpaRepository
- [x] TermUserJpaRepository
### userId 로 모든 Entity 삭제 메서드 구현
- [x] BoothUserService
- [x] TermUserService
### userId 에 해당하는 User 삭제 JPA 메서드 추가
- [x] UserJpaRepository
### userId 에 해당하는 User 삭제 메서드 구현
- [x] UserService
### Service
- [x] AuthService
### Controller
- [x] AuthController
### 사용자만 가능하도록
- [x] AuthenticationConfig

### API
| URL                     | method | Usage                   | Authorization Needed |
| ------------------ | ---------| -------------------- | ------------------------ |
|            /auth/users/withdraw                |      DELETE         |        회원 탈퇴                       |                O(사용자만)                    |

## Additional context
cascade.REMOVE 를 하면 부모 삭제 시 자식도 삭제된다.
하지만 이 과정에서 JPA 는 부모와 연관된 모든 자식들을 메모리에 먼저 올린 후 삭제를 수행한다.
이 과정에서 부모와 연관된 모든 자식들을 SELECT 쿼리를 통해 가져온다.
이는 N+1 문제이다.
cascade.REMOVE 에서 발생하는 성능 저하를 방지하기 위해서 JPQL 을 사용할 수 있다.
부모를 삭제할 때, 자식을 삭제하는 메서드를 전부 수행하게 해야 한다.
물론 객체지향적이 아니다. 부모가 자식에 대해 너무 많이 알아야 한다. 
하지만, 연관된 자식이 많아질수록, 혹은 열의 갯수가 많아질수록 성능 저하가 커지기 때문에, 객체지향적이지 않더라도 위 방식이 더 적합하다고 생각된다.

Closes #170 