### PR TITLE
Feature/#180 특정 부스만 도장판 이벤트에 참여하도록 변경

### DIFF
--- a/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
+++ b/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
@@ -57,7 +57,7 @@ public class BoothController {
     return ResponseEntity.ok(boothQueryService.getBooth(id));
   }
 
-  @GetMapping(GET_BOOTH_OWNERSHIP)
+  @GetMapping(GET_BOOTH_MANAGING_DETAIL)
   public ResponseEntity<BoothOwnershipResponse> isBoothOwner(
       @PathVariable final UUID id,
       @AuthenticationPrincipal final UUID boothAdminId) {

--- a/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
+++ b/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
@@ -3,7 +3,7 @@ package org.mju_likelion.festival.booth.controller;
 import static org.mju_likelion.festival.common.api.ApiPaths.GET_ALL_BOOTHS;
 import static org.mju_likelion.festival.common.api.ApiPaths.GET_ALL_BOOTH_DEPARTMENTS;
 import static org.mju_likelion.festival.common.api.ApiPaths.GET_BOOTH;
-import static org.mju_likelion.festival.common.api.ApiPaths.GET_BOOTH_OWNERSHIP;
+import static org.mju_likelion.festival.common.api.ApiPaths.GET_BOOTH_MANAGING_DETAIL;
 import static org.mju_likelion.festival.common.api.ApiPaths.ISSUE_BOOTH_QR;
 import static org.mju_likelion.festival.common.api.ApiPaths.PATCH_BOOTH;
 import static org.mju_likelion.festival.common.api.ApiPaths.VISIT_BOOTH;
@@ -14,7 +14,7 @@ import lombok.AllArgsConstructor;
 import org.mju_likelion.festival.booth.dto.request.UpdateBoothRequest;
 import org.mju_likelion.festival.booth.dto.response.BoothDepartmentResponse;
 import org.mju_likelion.festival.booth.dto.response.BoothDetailResponse;
-import org.mju_likelion.festival.booth.dto.response.BoothOwnershipResponse;
+import org.mju_likelion.festival.booth.dto.response.BoothManagingDetailResponse;
 import org.mju_likelion.festival.booth.dto.response.BoothQrResponse;
 import org.mju_likelion.festival.booth.dto.response.SimpleBoothsResponse;
 import org.mju_likelion.festival.booth.service.BoothQueryService;
@@ -58,11 +58,11 @@ public class BoothController {
   }
 
   @GetMapping(GET_BOOTH_MANAGING_DETAIL)
-  public ResponseEntity<BoothOwnershipResponse> isBoothOwner(
+  public ResponseEntity<BoothManagingDetailResponse> getBoothManagingDetail(
       @PathVariable final UUID id,
       @AuthenticationPrincipal final UUID boothAdminId) {
 
-    return ResponseEntity.ok(boothQueryService.isBoothOwner(id, boothAdminId));
+    return ResponseEntity.ok(boothQueryService.getBoothManagingDetail(id, boothAdminId));
   }
 
   @GetMapping(ISSUE_BOOTH_QR)

--- a/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/Booth.java
@@ -19,7 +19,7 @@ import org.mju_likelion.festival.image.domain.Image;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString(callSuper = true,
-    of = {"boothInfo", "locationImage", "image"})
+    of = {"boothInfo", "isEventBooth", "locationImage", "image"})
 @Entity(name = "booth")
 public class Booth extends BaseEntity {
 
@@ -29,6 +29,9 @@ public class Booth extends BaseEntity {
 
   @Embedded
   private BoothInfo boothInfo;
+
+  @Column(nullable = false)
+  private Boolean isEventBooth;
 
   @Column(nullable = false)
   private Short sequence;
@@ -44,12 +47,14 @@ public class Booth extends BaseEntity {
   public Booth(
       final Admin owner,
       final BoothInfo boothInfo,
+      final boolean isEventBooth,
       final Short sequence,
       final Image locationImage,
       final Image image) {
 
     this.owner = owner;
     this.boothInfo = boothInfo;
+    this.isEventBooth = isEventBooth;
     this.sequence = sequence;
     this.locationImage = locationImage;
     this.image = image;

--- a/src/main/java/org/mju_likelion/festival/booth/domain/repository/BoothQueryRepository.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/repository/BoothQueryRepository.java
@@ -106,6 +106,25 @@ public class BoothQueryRepository {
   }
 
   /**
+   * 이벤트 부스인지 확인.
+   *
+   * @param boothId 부스 ID
+   * @return 이벤트 부스 여부
+   */
+  public boolean isEventBooth(final UUID boothId) {
+    String sql =
+        "SELECT EXISTS("
+            + "SELECT 1 FROM booth b "
+            + "WHERE b.id = UNHEX(:boothId) AND b.is_event_booth = TRUE"
+            + ") AS isEventBooth";
+
+    MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("boothId", uuidToHex(boothId));
+
+    return jdbcTemplate.queryForObject(sql, params, Integer.class) > 0;
+  }
+
+  /**
    * 부스 상세 정보 조회.
    *
    * @param id 부스 ID

--- a/src/main/java/org/mju_likelion/festival/booth/dto/response/BoothManagingDetailResponse.java
+++ b/src/main/java/org/mju_likelion/festival/booth/dto/response/BoothManagingDetailResponse.java
@@ -22,6 +22,7 @@ public class BoothManagingDetailResponse {
   public String toString() {
     return "BoothOwnershipResponse{" +
         "isOwner=" + isOwner +
+        ", isEventBooth=" + isEventBooth +
         '}';
   }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/dto/response/BoothManagingDetailResponse.java
+++ b/src/main/java/org/mju_likelion/festival/booth/dto/response/BoothManagingDetailResponse.java
@@ -9,12 +9,13 @@ import lombok.Getter;
  */
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class BoothOwnershipResponse {
+public class BoothManagingDetailResponse {
 
   private final Boolean isOwner;
+  private final Boolean isEventBooth;
 
-  public static BoothOwnershipResponse from(final boolean isOwner) {
-    return new BoothOwnershipResponse(isOwner);
+  public static BoothManagingDetailResponse of(final boolean isOwner, final boolean isEventBooth) {
+    return new BoothManagingDetailResponse(isOwner, isEventBooth);
   }
 
   @Override

--- a/src/main/java/org/mju_likelion/festival/common/api/ApiPaths.java
+++ b/src/main/java/org/mju_likelion/festival/common/api/ApiPaths.java
@@ -29,7 +29,7 @@ public class ApiPaths {
   public static final String ISSUE_BOOTH_QR = BOOTHS + "/{id}/qr";
   public static final String VISIT_BOOTH = BOOTHS + "/{qrId}/visit";
   public static final String PATCH_BOOTH = BOOTHS + "/{id}";
-  public static final String GET_BOOTH_OWNERSHIP = BOOTHS + "/{id}/ownership";
+  public static final String GET_BOOTH_MANAGING_DETAIL = BOOTHS + "/{id}/managing-detail";
 
   // auth
   private static final String AUTH = "/auth";

--- a/src/main/java/org/mju_likelion/festival/common/authentication/config/AuthenticationConfig.java
+++ b/src/main/java/org/mju_likelion/festival/common/authentication/config/AuthenticationConfig.java
@@ -2,7 +2,7 @@ package org.mju_likelion.festival.common.authentication.config;
 
 import static org.mju_likelion.festival.common.api.ApiPaths.DELETE_LOST_ITEM;
 import static org.mju_likelion.festival.common.api.ApiPaths.FOUND_LOST_ITEM;
-import static org.mju_likelion.festival.common.api.ApiPaths.GET_BOOTH_OWNERSHIP;
+import static org.mju_likelion.festival.common.api.ApiPaths.GET_BOOTH_MANAGING_DETAIL;
 import static org.mju_likelion.festival.common.api.ApiPaths.GET_MY_STAMP;
 import static org.mju_likelion.festival.common.api.ApiPaths.ISSUE_BOOTH_QR;
 import static org.mju_likelion.festival.common.api.ApiPaths.PATCH_ANNOUNCEMENT;
@@ -52,7 +52,7 @@ public class AuthenticationConfig {
     registry.addInterceptor(boothAdminAuthenticationInterceptor)
         .addPathPatterns(ISSUE_BOOTH_QR)
         .addPathPatterns(PATCH_BOOTH)
-        .addPathPatterns(GET_BOOTH_OWNERSHIP);
+        .addPathPatterns(GET_BOOTH_MANAGING_DETAIL);
   }
 
   /**

--- a/src/test/java/org/mju_likelion/festival/booth/domain/repository/BoothJpaRepository.java
+++ b/src/test/java/org/mju_likelion/festival/booth/domain/repository/BoothJpaRepository.java
@@ -1,5 +1,6 @@
 package org.mju_likelion.festival.booth.domain.repository;
 
+import java.util.List;
 import java.util.UUID;
 import org.mju_likelion.festival.booth.domain.Booth;
 import org.mju_likelion.festival.booth.domain.BoothDepartment;
@@ -11,4 +12,5 @@ public interface BoothJpaRepository extends JpaRepository<Booth, UUID> {
 
   long countByBoothInfo_Department(BoothDepartment department);
 
+  List<Booth> findAllByIsEventBooth(boolean isEventBooth);
 }

--- a/src/test/java/org/mju_likelion/festival/booth/service/BoothQueryServiceTest.java
+++ b/src/test/java/org/mju_likelion/festival/booth/service/BoothQueryServiceTest.java
@@ -75,7 +75,8 @@ public class BoothQueryServiceTest {
     Admin admin = booth.getOwner();
 
     // when
-    boolean isOwner = boothQueryService.isBoothOwner(booth.getId(), admin.getId()).getIsOwner();
+    boolean isOwner = boothQueryService.getBoothManagingDetail(booth.getId(), admin.getId())
+        .getIsOwner();
 
     // then
     assertThat(isOwner).isTrue();
@@ -91,7 +92,8 @@ public class BoothQueryServiceTest {
     Admin adminB = boothB.getOwner();
 
     // when
-    boolean isOwner = boothQueryService.isBoothOwner(boothA.getId(), adminB.getId()).getIsOwner();
+    boolean isOwner = boothQueryService.getBoothManagingDetail(boothA.getId(), adminB.getId())
+        .getIsOwner();
 
     // then
     assertThat(isOwner).isFalse();

--- a/src/test/java/org/mju_likelion/festival/booth/service/BoothQueryServiceTest.java
+++ b/src/test/java/org/mju_likelion/festival/booth/service/BoothQueryServiceTest.java
@@ -99,6 +99,38 @@ public class BoothQueryServiceTest {
     assertThat(isOwner).isFalse();
   }
 
+  @DisplayName("이벤트 부스 여부를 확인한다 - 이벤트 부스")
+  @Test
+  public void testIsEventBooth() {
+    // given
+    Booth booth = boothJpaRepository.findAllByIsEventBooth(true).get(0);
+    Admin admin = booth.getOwner();
+
+    // when
+    boolean isEventBooth = boothQueryService.getBoothManagingDetail(booth.getId(),
+            admin.getId())
+        .getIsEventBooth();
+
+    // then
+    assertThat(isEventBooth).isTrue();
+  }
+
+  @DisplayName("이벤트 부스 여부를 확인한다 - 일반 부스")
+  @Test
+  public void testIsNotEventBooth() {
+    // given
+    Booth booth = boothJpaRepository.findAllByIsEventBooth(false).get(0);
+    Admin admin = booth.getOwner();
+
+    // when
+    boolean isEventBooth = boothQueryService.getBoothManagingDetail(booth.getId(),
+            admin.getId())
+        .getIsEventBooth();
+
+    // then
+    assertThat(isEventBooth).isFalse();
+  }
+
   @DisplayName("RedisBoothQrManager 를 사용하여 부스 QR 코드를 생성한다.")
   @Test
   public void testCreateBoothQrRedisBoothQrManager() {


### PR DESCRIPTION
## Description
특정 부스만 도장판 이벤트에 참여하도록 변경

이에 따라, 부스 소유 여부 확인 API 를 변경
/booths/{id}/ownership  -> /booths/{boothId}/managing-detail
## Changes
### isEventBooth 컬럼 추가
- [x] Booth
### DTO 변경 
- [x] BoothOwnershipResponse -> BoothManagingDetailResponse
- [x] isEventBooth 필드 추가
### API 경로 변경 /booths/{boothId}/ownership   ->  /booths/{boothId}/managing-detail
- [x] ApiPaths
- [x] BoothController
- [x] AuthenticationConfig
### 이벤트 부스인지 확인 함수 구현
- [x] BoothQueryRepository
### Service 코드 변경
- [x] BoothQueryService
### DTO 변경에 따른 테스트 코드 리팩터링
- [x] BoothQueryServiceTest
### 이벤트 부스 확인 테스트 코드 작성
- [x] BoothQueryServiceTest

### API
| URL                     | method | Usage                   | Authorization Needed |
| ------------------ | ---------| -------------------- | ------------------------ |
|           /booths/{boothId}/managing-detail             |      GET |        부스 관리 디테일 조회            |           O(부스 관리자만)      |

## Additional context
Closes #180 