### PR TITLE
Feature/#182 부스 전체 조회 시 description 반환하지 않도록 변경

### DIFF
--- a/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
+++ b/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
@@ -44,7 +44,7 @@ public class BoothController {
   }
 
   @GetMapping(GET_ALL_BOOTHS)
-  public ResponseEntity<SimpleBoothsResponse> getBooths(
+  public ResponseEntity<List<SimpleBoothsResponse>> getBooths(
       @RequestParam(name = "department_id") final UUID departmentId) {
 
     return ResponseEntity.ok(boothQueryService.getBooths(departmentId));

--- a/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
+++ b/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
@@ -16,7 +16,7 @@ import org.mju_likelion.festival.booth.dto.response.BoothDepartmentResponse;
 import org.mju_likelion.festival.booth.dto.response.BoothDetailResponse;
 import org.mju_likelion.festival.booth.dto.response.BoothManagingDetailResponse;
 import org.mju_likelion.festival.booth.dto.response.BoothQrResponse;
-import org.mju_likelion.festival.booth.dto.response.SimpleBoothsResponse;
+import org.mju_likelion.festival.booth.dto.response.SimpleBoothResponse;
 import org.mju_likelion.festival.booth.service.BoothQueryService;
 import org.mju_likelion.festival.booth.service.BoothService;
 import org.mju_likelion.festival.booth.util.qr.BoothQrStrategy;
@@ -44,7 +44,7 @@ public class BoothController {
   }
 
   @GetMapping(GET_ALL_BOOTHS)
-  public ResponseEntity<List<SimpleBoothsResponse>> getBooths(
+  public ResponseEntity<List<SimpleBoothResponse>> getBooths(
       @RequestParam(name = "department_id") final UUID departmentId) {
 
     return ResponseEntity.ok(boothQueryService.getBooths(departmentId));

--- a/src/main/java/org/mju_likelion/festival/booth/domain/BoothDetail.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/BoothDetail.java
@@ -8,8 +8,12 @@ import lombok.Getter;
  * 부스 상세 정보.
  */
 @Getter
-public class BoothDetail extends SimpleBooth {
+public class BoothDetail {
 
+  private final UUID id;
+  private final String name;
+  private final String imageUrl;
+  private final String description;
   private final String department;
   private final String location;
   private final String locationImageUrl;
@@ -25,7 +29,10 @@ public class BoothDetail extends SimpleBooth {
       final String locationImageUrl,
       final LocalDateTime createdAt) {
 
-    super(id, name, description, imageUrl);
+    this.id = id;
+    this.name = name;
+    this.imageUrl = imageUrl;
+    this.description = description;
     this.department = department;
     this.location = location;
     this.locationImageUrl = locationImageUrl;

--- a/src/main/java/org/mju_likelion/festival/booth/domain/SimpleBooth.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/SimpleBooth.java
@@ -13,7 +13,6 @@ public class SimpleBooth {
 
   protected final UUID id;
   protected final String name;
-  protected final String description;
   protected final String imageUrl;
 
   @Override
@@ -21,7 +20,6 @@ public class SimpleBooth {
     return "SimpleBooth{" +
         "id=" + id +
         ", name='" + name + '\'' +
-        ", description='" + description + '\'' +
         ", imageUrl='" + imageUrl + '\'' +
         '}';
   }

--- a/src/main/java/org/mju_likelion/festival/booth/domain/SimpleBooth.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/SimpleBooth.java
@@ -11,9 +11,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public class SimpleBooth {
 
-  protected final UUID id;
-  protected final String name;
-  protected final String imageUrl;
+  private final UUID id;
+  private final String name;
+  private final String imageUrl;
 
   @Override
   public String toString() {

--- a/src/main/java/org/mju_likelion/festival/booth/domain/repository/BoothQueryRepository.java
+++ b/src/main/java/org/mju_likelion/festival/booth/domain/repository/BoothQueryRepository.java
@@ -35,7 +35,6 @@ public class BoothQueryRepository {
       return new SimpleBooth(
           uuid,
           rs.getString("boothName"),
-          rs.getString("boothDescription"),
           rs.getString("imageUrl")
       );
     };
@@ -71,7 +70,7 @@ public class BoothQueryRepository {
   public List<SimpleBooth> findAllSimpleBoothByDepartmentId(final UUID departmentId) {
 
     String sql =
-        "SELECT HEX(b.id) AS boothId, b.name AS boothName, b.description AS boothDescription, "
+        "SELECT HEX(b.id) AS boothId, b.name AS boothName, "
             + "i.url AS imageUrl "
             + "FROM booth b "
             + "INNER JOIN image i ON b.image_id = i.id "

--- a/src/main/java/org/mju_likelion/festival/booth/dto/response/SimpleBoothResponse.java
+++ b/src/main/java/org/mju_likelion/festival/booth/dto/response/SimpleBoothResponse.java
@@ -10,15 +10,15 @@ import org.mju_likelion.festival.booth.domain.SimpleBooth;
  */
 @Getter
 @AllArgsConstructor
-public class SimpleBoothsResponse {
+public class SimpleBoothResponse {
 
   private final UUID id;
   private final String name;
   private final String imageUrl;
 
-  public static SimpleBoothsResponse from(final SimpleBooth simpleBooths) {
+  public static SimpleBoothResponse from(final SimpleBooth simpleBooths) {
 
-    return new SimpleBoothsResponse(simpleBooths.getId(), simpleBooths.getName(),
+    return new SimpleBoothResponse(simpleBooths.getId(), simpleBooths.getName(),
         simpleBooths.getImageUrl());
   }
 

--- a/src/main/java/org/mju_likelion/festival/booth/dto/response/SimpleBoothsResponse.java
+++ b/src/main/java/org/mju_likelion/festival/booth/dto/response/SimpleBoothsResponse.java
@@ -1,6 +1,6 @@
 package org.mju_likelion.festival.booth.dto.response;
 
-import java.util.List;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.mju_likelion.festival.booth.domain.SimpleBooth;
@@ -12,17 +12,22 @@ import org.mju_likelion.festival.booth.domain.SimpleBooth;
 @AllArgsConstructor
 public class SimpleBoothsResponse {
 
-  private final List<SimpleBooth> simpleBooths;
+  private final UUID id;
+  private final String name;
+  private final String imageUrl;
 
-  public static SimpleBoothsResponse from(final List<SimpleBooth> simpleBooths) {
+  public static SimpleBoothsResponse from(final SimpleBooth simpleBooths) {
 
-    return new SimpleBoothsResponse(simpleBooths);
+    return new SimpleBoothsResponse(simpleBooths.getId(), simpleBooths.getName(),
+        simpleBooths.getImageUrl());
   }
 
   @Override
   public String toString() {
     return "SimpleBoothsResponse{" +
-        "simpleBooths=" + simpleBooths +
+        "id=" + id +
+        ", name='" + name + '\'' +
+        ", imageUrl='" + imageUrl + '\'' +
         '}';
   }
 }

--- a/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
@@ -46,13 +46,15 @@ public class BoothQueryService {
         .toList();
   }
 
-  public SimpleBoothsResponse getBooths(final UUID departmentId) {
+  public List<SimpleBoothsResponse> getBooths(final UUID departmentId) {
     validateBoothDepartment(departmentId);
 
     List<SimpleBooth> simpleBooths = boothQueryRepository.findAllSimpleBoothByDepartmentId(
         departmentId);
 
-    return SimpleBoothsResponse.from(simpleBooths);
+    return simpleBooths.stream()
+        .map(SimpleBoothsResponse::from)
+        .toList();
   }
 
   public BoothDetailResponse getBooth(final UUID id) {

--- a/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
@@ -21,7 +21,7 @@ import org.mju_likelion.festival.booth.dto.response.BoothDepartmentResponse;
 import org.mju_likelion.festival.booth.dto.response.BoothDetailResponse;
 import org.mju_likelion.festival.booth.dto.response.BoothManagingDetailResponse;
 import org.mju_likelion.festival.booth.dto.response.BoothQrResponse;
-import org.mju_likelion.festival.booth.dto.response.SimpleBoothsResponse;
+import org.mju_likelion.festival.booth.dto.response.SimpleBoothResponse;
 import org.mju_likelion.festival.booth.util.qr.manager.BoothQrManager;
 import org.mju_likelion.festival.common.exception.BadRequestException;
 import org.mju_likelion.festival.common.exception.ForbiddenException;
@@ -46,14 +46,14 @@ public class BoothQueryService {
         .toList();
   }
 
-  public List<SimpleBoothsResponse> getBooths(final UUID departmentId) {
+  public List<SimpleBoothResponse> getBooths(final UUID departmentId) {
     validateBoothDepartment(departmentId);
 
     List<SimpleBooth> simpleBooths = boothQueryRepository.findAllSimpleBoothByDepartmentId(
         departmentId);
 
     return simpleBooths.stream()
-        .map(SimpleBoothsResponse::from)
+        .map(SimpleBoothResponse::from)
         .toList();
   }
 

--- a/src/test/java/org/mju_likelion/festival/booth/service/BoothQueryServiceTest.java
+++ b/src/test/java/org/mju_likelion/festival/booth/service/BoothQueryServiceTest.java
@@ -47,10 +47,11 @@ public class BoothQueryServiceTest {
     BoothDepartment department = boothDepartmentJpaRepository.findAll().get(0);
 
     // when
-    SimpleBoothsResponse booths = boothQueryService.getBooths(department.getId());
+    List<SimpleBoothsResponse> simpleBoothsResponses = boothQueryService.getBooths(
+        department.getId());
 
     // then
-    assertThat(booths.getSimpleBooths()).isNotEmpty();
+    assertThat(simpleBoothsResponses).isNotEmpty();
   }
 
   @DisplayName("부스 상세 정보 조회")

--- a/src/test/java/org/mju_likelion/festival/booth/service/BoothQueryServiceTest.java
+++ b/src/test/java/org/mju_likelion/festival/booth/service/BoothQueryServiceTest.java
@@ -14,7 +14,7 @@ import org.mju_likelion.festival.booth.domain.BoothDepartment;
 import org.mju_likelion.festival.booth.domain.repository.BoothDepartmentJpaRepository;
 import org.mju_likelion.festival.booth.domain.repository.BoothJpaRepository;
 import org.mju_likelion.festival.booth.dto.response.BoothDetailResponse;
-import org.mju_likelion.festival.booth.dto.response.SimpleBoothsResponse;
+import org.mju_likelion.festival.booth.dto.response.SimpleBoothResponse;
 import org.mju_likelion.festival.booth.util.qr.manager.BoothQrManagerContext;
 import org.mju_likelion.festival.booth.util.qr.manager.RedisBoothQrManager;
 import org.mju_likelion.festival.booth.util.qr.manager.TokenBoothQrManager;
@@ -47,11 +47,11 @@ public class BoothQueryServiceTest {
     BoothDepartment department = boothDepartmentJpaRepository.findAll().get(0);
 
     // when
-    List<SimpleBoothsResponse> simpleBoothsResponses = boothQueryService.getBooths(
+    List<SimpleBoothResponse> simpleBoothResponses = boothQueryService.getBooths(
         department.getId());
 
     // then
-    assertThat(simpleBoothsResponses).isNotEmpty();
+    assertThat(simpleBoothResponses).isNotEmpty();
   }
 
   @DisplayName("부스 상세 정보 조회")


### PR DESCRIPTION
## Description
부스 전체 조회 시 description 반환하지 않도록 변경
## Changes
### BoothDetail 이 SimpleBooth 를 상속받지 않도록 (DTO 간의 의존성이 너무 강했음)
- [x] BoothDetail
- [x] SimpleBooth
### SimpleBooth 에서 description 필드 제거
- [x] SimpleBooth
- [x] BoothQueryRepository
### `List<SimpleBooth>` 로 포장해서 반환하지 않도록
- [x] SimpleBoothsResponse
###  `List<SimpleBoothsResponse>` 를 반환하도록
- [x] BoothQueryService
- [x] BoothController
### `List<SimpleBoothsResponse>` 반환에 따른 테스트 코드 수정
- [x] BoothQueryServiceTest

## Additional context
Closes #182 