### PR TITLE
Feature/#197 소속 별 부스 리스트 조회 캐싱 적용

### DIFF
--- a/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
+++ b/src/main/java/org/mju_likelion/festival/booth/controller/BoothController.java
@@ -16,7 +16,7 @@ import org.mju_likelion.festival.booth.dto.response.BoothAffiliationResponse;
 import org.mju_likelion.festival.booth.dto.response.BoothDetailResponse;
 import org.mju_likelion.festival.booth.dto.response.BoothManagingDetailResponse;
 import org.mju_likelion.festival.booth.dto.response.BoothQrResponse;
-import org.mju_likelion.festival.booth.dto.response.SimpleBoothResponse;
+import org.mju_likelion.festival.booth.dto.response.SimpleBoothResponses;
 import org.mju_likelion.festival.booth.service.BoothQueryService;
 import org.mju_likelion.festival.booth.service.BoothService;
 import org.mju_likelion.festival.booth.util.qr.BoothQrStrategy;
@@ -44,7 +44,7 @@ public class BoothController {
   }
 
   @GetMapping(GET_ALL_BOOTHS)
-  public ResponseEntity<List<SimpleBoothResponse>> getBooths(
+  public ResponseEntity<SimpleBoothResponses> getBooths(
       @RequestParam(name = "affiliation_id") final UUID affiliationId) {
 
     return ResponseEntity.ok(boothQueryService.getBooths(affiliationId));

--- a/src/main/java/org/mju_likelion/festival/booth/dto/response/SimpleBoothResponse.java
+++ b/src/main/java/org/mju_likelion/festival/booth/dto/response/SimpleBoothResponse.java
@@ -1,21 +1,24 @@
 package org.mju_likelion.festival.booth.dto.response;
 
 import java.util.UUID;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.mju_likelion.festival.booth.domain.SimpleBooth;
 
 /**
  * 부스 간단 정보 응답 DTO.
  */
 @Getter
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 public class SimpleBoothResponse {
 
-  private final UUID id;
-  private final String departmentName;
-  private final String name;
-  private final String imageUrl;
+  private UUID id;
+  private String departmentName;
+  private String name;
+  private String imageUrl;
 
   public static SimpleBoothResponse from(final SimpleBooth simpleBooths) {
 

--- a/src/main/java/org/mju_likelion/festival/booth/dto/response/SimpleBoothResponses.java
+++ b/src/main/java/org/mju_likelion/festival/booth/dto/response/SimpleBoothResponses.java
@@ -1,0 +1,26 @@
+package org.mju_likelion.festival.booth.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class SimpleBoothResponses {
+
+  private List<SimpleBoothResponse> simpleBoothResponseList;
+
+  public static SimpleBoothResponses from(final List<SimpleBoothResponse> simpleBoothResponses) {
+    return new SimpleBoothResponses(simpleBoothResponses);
+  }
+
+  @Override
+  public String toString() {
+    return "SimpleBoothResponses{" +
+        "simpleBoothResponseList=" + simpleBoothResponseList +
+        '}';
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
@@ -48,6 +48,7 @@ public class BoothQueryService {
         .toList();
   }
 
+  @Cacheable(value = "simpleBooths", key = "#affiliationId")
   public SimpleBoothResponses getBooths(final UUID affiliationId) {
     validateBoothDepartment(affiliationId);
 

--- a/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
@@ -22,6 +22,7 @@ import org.mju_likelion.festival.booth.dto.response.BoothDetailResponse;
 import org.mju_likelion.festival.booth.dto.response.BoothManagingDetailResponse;
 import org.mju_likelion.festival.booth.dto.response.BoothQrResponse;
 import org.mju_likelion.festival.booth.dto.response.SimpleBoothResponse;
+import org.mju_likelion.festival.booth.dto.response.SimpleBoothResponses;
 import org.mju_likelion.festival.booth.util.qr.manager.BoothQrManager;
 import org.mju_likelion.festival.common.exception.BadRequestException;
 import org.mju_likelion.festival.common.exception.ForbiddenException;
@@ -47,15 +48,17 @@ public class BoothQueryService {
         .toList();
   }
 
-  public List<SimpleBoothResponse> getBooths(final UUID affiliationId) {
+  public SimpleBoothResponses getBooths(final UUID affiliationId) {
     validateBoothDepartment(affiliationId);
 
     List<SimpleBooth> simpleBooths = boothQueryRepository.findAllSimpleBoothByAffiliationId(
         affiliationId);
 
-    return simpleBooths.stream()
+    List<SimpleBoothResponse> simpleBoothResponseList = simpleBooths.stream()
         .map(SimpleBoothResponse::from)
         .toList();
+
+    return SimpleBoothResponses.from(simpleBoothResponseList);
   }
 
   public BoothDetailResponse getBooth(final UUID id) {

--- a/src/test/java/org/mju_likelion/festival/booth/service/BoothQueryServiceTest.java
+++ b/src/test/java/org/mju_likelion/festival/booth/service/BoothQueryServiceTest.java
@@ -14,7 +14,7 @@ import org.mju_likelion.festival.booth.domain.BoothAffiliation;
 import org.mju_likelion.festival.booth.domain.repository.BoothAffiliationJpaRepository;
 import org.mju_likelion.festival.booth.domain.repository.BoothJpaRepository;
 import org.mju_likelion.festival.booth.dto.response.BoothDetailResponse;
-import org.mju_likelion.festival.booth.dto.response.SimpleBoothResponse;
+import org.mju_likelion.festival.booth.dto.response.SimpleBoothResponses;
 import org.mju_likelion.festival.booth.util.qr.manager.BoothQrManagerContext;
 import org.mju_likelion.festival.booth.util.qr.manager.RedisBoothQrManager;
 import org.mju_likelion.festival.booth.util.qr.manager.TokenBoothQrManager;
@@ -47,11 +47,11 @@ public class BoothQueryServiceTest {
     BoothAffiliation affiliation = boothAffiliationJpaRepository.findAll().get(0);
 
     // when
-    List<SimpleBoothResponse> simpleBoothResponses = boothQueryService.getBooths(
+    SimpleBoothResponses simpleBoothResponses = boothQueryService.getBooths(
         affiliation.getId());
 
     // then
-    assertThat(simpleBoothResponses).isNotEmpty();
+    assertThat(simpleBoothResponses.getSimpleBoothResponseList()).isNotEmpty();
   }
 
   @DisplayName("부스 상세 정보 조회")


### PR DESCRIPTION
## Description
소속 별 부스 리스트 조회 캐싱 적용
## Changes
### `List<SimpleBoothResponse>` 를 포장해서 반환하도록
- [x] SimpleBoothResponses
- [x] BoothQueryService
- [x] BoothController
### 캐싱 적용
- [x] BoothQueryService

## Additional context
Closes #197 