### PR TITLE
Feature/#205 부스 상세 조회 캐싱 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 
     implementation 'org.springframework.security:spring-security-crypto'// Security
 
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'// Jackson
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/org/mju_likelion/festival/booth/dto/response/BoothDetailResponse.java
+++ b/src/main/java/org/mju_likelion/festival/booth/dto/response/BoothDetailResponse.java
@@ -1,10 +1,16 @@
 package org.mju_likelion.festival.booth.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.mju_likelion.festival.booth.domain.BoothDetail;
 
 /**
@@ -12,16 +18,20 @@ import org.mju_likelion.festival.booth.domain.BoothDetail;
  */
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 public class BoothDetailResponse {
 
-  private final UUID id;
-  private final String name;
-  private final String description;
-  private final String department;
-  private final String location;
-  private final String imageUrl;
-  private final String locationImageUrl;
-  private final LocalDateTime createdAt;
+  private UUID id;
+  private String name;
+  private String description;
+  private String department;
+  private String location;
+  private String imageUrl;
+  private String locationImageUrl;
+  @JsonSerialize(using = LocalDateTimeSerializer.class)
+  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+  private LocalDateTime createdAt;
 
   public static BoothDetailResponse from(final BoothDetail boothDetail) {
     return new BoothDetailResponse(boothDetail.getId(), boothDetail.getName(),

--- a/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
@@ -62,6 +62,7 @@ public class BoothQueryService {
     return SimpleBoothResponses.from(simpleBoothResponseList);
   }
 
+  @Cacheable(value = "boothDetail", key = "#id")
   public BoothDetailResponse getBooth(final UUID id) {
     return BoothDetailResponse.from(getExistingBoothDetail(id));
   }

--- a/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
+++ b/src/main/java/org/mju_likelion/festival/booth/service/BoothQueryService.java
@@ -66,7 +66,7 @@ public class BoothQueryService {
     return BoothDetailResponse.from(getExistingBoothDetail(id));
   }
 
-  @Cacheable(value = "boothDetails", key = "#boothId + ' : ' + #boothAdminId")
+  @Cacheable(value = "boothManagingDetail", key = "#boothId + ' : ' + #boothAdminId")
   public BoothManagingDetailResponse getBoothManagingDetail(final UUID boothId,
       final UUID boothAdminId) {
     validateBoothExistence(boothId);

--- a/src/main/java/org/mju_likelion/festival/booth/service/BoothService.java
+++ b/src/main/java/org/mju_likelion/festival/booth/service/BoothService.java
@@ -11,6 +11,7 @@ import org.mju_likelion.festival.booth.util.qr.BoothQrStrategy;
 import org.mju_likelion.festival.booth.util.qr.manager.BoothQrManager;
 import org.mju_likelion.festival.user.domain.User;
 import org.mju_likelion.festival.user.service.UserQueryService;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +43,7 @@ public class BoothService {
     userQueryService.saveUser(user);
   }
 
+  @CacheEvict(value = "boothDetail", key = "#boothId")
   public void updateBooth(
       final UUID boothId,
       final UpdateBoothRequest updateBoothRequest,


### PR DESCRIPTION
## Description
부스 상세 조회 캐싱 적용
## Changes
### Jackson 직/역직렬화를 위한 의존성 추가 ( Redis 사용 시 LocalDateTime 직/역직력화 문제 발생)
- [x] build.gradle
### 직/역직렬화를 위한 어노테이션 추가
- [x] BoothDetailResponse
### 부스 상세 정보 캐싱하도록
- [x] BoothQueryService
### 부스 정보 업데이트 시 캐시 무효화하도록
- [x] BoothService
## Additional context
Closes #205 