### PR TITLE
Feature/#211 캐싱 서킷 브레이커 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'// Jackson
 
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.0.2'// Resilience4j
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/org/mju_likelion/festival/common/circuit_breaker/FallBackUtil.java
+++ b/src/main/java/org/mju_likelion/festival/common/circuit_breaker/FallBackUtil.java
@@ -1,0 +1,26 @@
+package org.mju_likelion.festival.common.circuit_breaker;
+
+import lombok.extern.slf4j.Slf4j;
+import org.mju_likelion.festival.common.exception.CustomException;
+
+@Slf4j
+public class FallBackUtil {
+
+  public static void handleFallBack(final Exception e) {
+    if (e instanceof CustomException) {
+      throw (CustomException) e;
+    }
+
+    StackTraceElement[] stackTrace = new Throwable().getStackTrace();
+    StackTraceElement caller = stackTrace[1];
+    writeLog(e, caller);
+  }
+
+  private static void writeLog(final Exception e, final StackTraceElement caller) {
+    log.info("Fallback to method {}(): {}, {}",
+        caller.getMethodName(),
+        e.getClass().getSimpleName(),
+        e.getMessage()
+    );
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/common/config/Resilience4jConfig.java
+++ b/src/main/java/org/mju_likelion/festival/common/config/Resilience4jConfig.java
@@ -1,0 +1,34 @@
+package org.mju_likelion.festival.common.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.lettuce.core.RedisException;
+import java.time.Duration;
+import org.mju_likelion.festival.common.exception.CustomException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.RedisSystemException;
+
+@Configuration
+public class Resilience4jConfig {
+
+  public static final String REDIS_CIRCUIT_BREAKER = "redis";
+
+  @Bean
+  public CircuitBreakerRegistry redisCircuitBreakerRegistry() {
+    CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
+        .failureRateThreshold(80)
+        .slidingWindowSize(10)
+        .permittedNumberOfCallsInHalfOpenState(5)
+        .waitDurationInOpenState(Duration.ofHours(1))
+        .recordExceptions(RedisException.class, RedisSystemException.class,
+            RedisConnectionFailureException.class)
+        .ignoreExceptions(CustomException.class)
+        .build();
+
+    CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.of(circuitBreakerConfig);
+    circuitBreakerRegistry.circuitBreaker(REDIS_CIRCUIT_BREAKER, circuitBreakerConfig);
+    return circuitBreakerRegistry;
+  }
+}

--- a/src/main/java/org/mju_likelion/festival/lost_item/service/LostItemService.java
+++ b/src/main/java/org/mju_likelion/festival/lost_item/service/LostItemService.java
@@ -1,11 +1,14 @@
 package org.mju_likelion.festival.lost_item.service;
 
+import static org.mju_likelion.festival.common.config.Resilience4jConfig.REDIS_CIRCUIT_BREAKER;
 import static org.mju_likelion.festival.common.util.null_handler.NullHandler.doIfNotNull;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.mju_likelion.festival.admin.domain.Admin;
 import org.mju_likelion.festival.admin.service.AdminQueryService;
+import org.mju_likelion.festival.common.circuit_breaker.FallBackUtil;
 import org.mju_likelion.festival.image.domain.Image;
 import org.mju_likelion.festival.lost_item.domain.LostItem;
 import org.mju_likelion.festival.lost_item.domain.repository.LostItemJpaRepository;
@@ -42,7 +45,26 @@ public class LostItemService {
   }
 
   @CacheEvict(value = "lostItem", key = "#lostItemId")
+  @CircuitBreaker(name = REDIS_CIRCUIT_BREAKER, fallbackMethod = "updateLostItemFallback")
   public void updateLostItem(
+      final UUID lostItemId,
+      final UpdateLostItemRequest updateLostItemRequest,
+      final UUID studentCouncilId) {
+
+    updateLostItemLogic(lostItemId, updateLostItemRequest, studentCouncilId);
+  }
+
+  public void updateLostItemFallback(
+      final UUID lostItemId,
+      final UpdateLostItemRequest updateLostItemRequest,
+      final UUID studentCouncilId,
+      final Exception e) {
+
+    FallBackUtil.handleFallBack(e);
+    updateLostItemLogic(lostItemId, updateLostItemRequest, studentCouncilId);
+  }
+
+  private void updateLostItemLogic(
       final UUID lostItemId,
       final UpdateLostItemRequest updateLostItemRequest,
       final UUID studentCouncilId) {
@@ -55,8 +77,27 @@ public class LostItemService {
     lostItemJpaRepository.save(lostItem);
   }
 
-  @CacheEvict(value = "lostItem", key = "#lostItemId")
+  @CacheEvict(value = "lostItem", key = "#lostItemId", beforeInvocation = true)
+  @CircuitBreaker(name = REDIS_CIRCUIT_BREAKER, fallbackMethod = "foundLostItemFallback")
   public void foundLostItem(
+      final UUID lostItemId,
+      final LostItemFoundRequest lostItemFoundRequest,
+      final UUID studentCouncilId) {
+
+    foundLostItemLogic(lostItemId, lostItemFoundRequest, studentCouncilId);
+  }
+
+  public void foundLostItemFallback(
+      final UUID lostItemId,
+      final LostItemFoundRequest lostItemFoundRequest,
+      final UUID studentCouncilId,
+      final Exception e) {
+
+    FallBackUtil.handleFallBack(e);
+    foundLostItemLogic(lostItemId, lostItemFoundRequest, studentCouncilId);
+  }
+
+  public void foundLostItemLogic(
       final UUID lostItemId,
       final LostItemFoundRequest lostItemFoundRequest,
       final UUID studentCouncilId) {
@@ -70,7 +111,21 @@ public class LostItemService {
   }
 
   @CacheEvict(value = "lostItem", key = "#lostItemId")
+  @CircuitBreaker(name = REDIS_CIRCUIT_BREAKER, fallbackMethod = "deleteLostItemFallback")
   public void deleteLostItem(final UUID lostItemId, final UUID studentCouncilId) {
+    deleteLostItemLogic(lostItemId, studentCouncilId);
+  }
+
+  public void deleteLostItemFallback(
+      final UUID lostItemId,
+      final UUID studentCouncilId,
+      final Exception e) {
+
+    FallBackUtil.handleFallBack(e);
+    deleteLostItemLogic(lostItemId, studentCouncilId);
+  }
+
+  private void deleteLostItemLogic(final UUID lostItemId, final UUID studentCouncilId) {
     LostItem lostItem = lostItemQueryService.getExistLostItem(lostItemId);
     adminQueryService.validateAdminExistence(studentCouncilId);
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -19,6 +19,18 @@
     </rollingPolicy>
   </appender>
 
+  <!-- Rolling File appender for fallback logs (INFO, WARN, ERROR) -->
+  <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FALLBACK_FILE">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %msg%n%n</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>logs/fallback/fallback[%d{yyyy-MM-dd}].log</fileNamePattern>
+      <maxHistory>10</maxHistory>
+    </rollingPolicy>
+  </appender>
+
+
   <!-- Rolling File appender for SQL logs -->
   <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="SQL_FILE">
     <encoder>
@@ -41,6 +53,10 @@
   <!-- Root logger configuration for request logs -->
   <logger level="DEBUG" name="org.mju_likelion.festival.common.logging.LoggingAspect">
     <appender-ref ref="REQUEST_FILE"/>
+  </logger>
+
+  <logger level="DEBUG" name="org.mju_likelion.festival.common.circuit_breaker.FallBackUtil">
+    <appender-ref ref="FALLBACK_FILE"/>
   </logger>
 
   <!-- Root logger configuration for console output -->


### PR DESCRIPTION
## Description

## Changes
### Resilience4j 의존성 추가
- [x] build.gradle
### Resilience4j 설정 파일 
- [x] Resilience4jConfig
### FallBack 시 로깅하기 위한 Util
- [x] FallBackUtil
### FallBack 시 로깅하도록
- [x] logback-spring.xml
### Redis 를 사용해 캐싱하는 모든 곳에 Circuit Breaker 적용
- [x] BoothService
- [x] BoothQueryService
- [x] LostItemService
- [x] LostItemQueryService
- [x] TermQueryService

## Additional context
- 최근 10 번의 요청 동안 80%의 요청에서 문제 발생 시 open
- 1 시간 동안 open 되어 있다가 5번의 요청을 정상적으로 수행하면 close
- Redis 관련 Exception 만 record 하도록


Closes #211 